### PR TITLE
Make XmlCursor AutoCloseable 

### DIFF
--- a/src/main/java/org/apache/xmlbeans/XmlCursor.java
+++ b/src/main/java/org/apache/xmlbeans/XmlCursor.java
@@ -128,7 +128,7 @@ import java.util.Map;
  * creating a brand new instance of an empty document. Also note that
  * attributes may only follow container tokens (STARTDOC or START)
  */
-public interface XmlCursor extends XmlTokenSource {
+public interface XmlCursor extends XmlTokenSource, AutoCloseable {
     /**
      * An enumeration that identifies the type of an XML token.
      */
@@ -335,11 +335,29 @@ public interface XmlCursor extends XmlTokenSource {
      * So, explicitly disposing a cursor allows the underlying implementation
      * to release its responsibility of maintaining its position.
      * <p>
-     * After a cursor has been disposed, it may not be used again.  It can
+     * After a cursor has been closed, it may not be used again.  It can
      * throw IllegalStateException or NullPointerException if used after
      * disposal.
+     * <p>
+     * XmlCursor implements <code>java.lang.AutoCloseable</code> and the
+     * try-with-resources pattern is recommended.<br/><br/>
+     * <p>
+     * Note: Future major release will remove this default implementation.
      */
 
+    default void close() {
+        this.dispose();
+    }
+
+    /**
+     * Deallocates resources needed to manage the cursor. For details see
+     * {@link #close()}. XmlCursor implements <code>java.lang.AutoCloseable</code>
+     * and the try-with-resources pattern is recommended.
+     *
+     * @see #close()
+     */
+
+    @Deprecated
     void dispose();
 
     /**

--- a/src/main/java/org/apache/xmlbeans/XmlCursor.java
+++ b/src/main/java/org/apache/xmlbeans/XmlCursor.java
@@ -1460,10 +1460,6 @@ public interface XmlCursor extends XmlTokenSource, AutoCloseable {
          * @param c the cursor to be moved
          * @return the given cursor moved to this bookmark
          */
-        // TODO Problematic API for an AutoCloseable XmlCursor, it returns the same
-        // cursor or a new one, client code would need to check if it is different
-        // in order to close it
-        @SuppressWarnings("resource")
         public final XmlCursor toBookmark(XmlCursor c) {
             return c == null || !c.toBookmark(this) ? createCursor() : c;
         }

--- a/src/main/java/org/apache/xmlbeans/XmlCursor.java
+++ b/src/main/java/org/apache/xmlbeans/XmlCursor.java
@@ -1460,6 +1460,10 @@ public interface XmlCursor extends XmlTokenSource, AutoCloseable {
          * @param c the cursor to be moved
          * @return the given cursor moved to this bookmark
          */
+        // TODO Problematic API for an AutoCloseable XmlCursor, it returns the same
+        // cursor or a new one, client code would need to check if it is different
+        // in order to close it
+        @SuppressWarnings("resource")
         public final XmlCursor toBookmark(XmlCursor c) {
             return c == null || !c.toBookmark(this) ? createCursor() : c;
         }

--- a/src/main/java/org/apache/xmlbeans/XmlError.java
+++ b/src/main/java/org/apache/xmlbeans/XmlError.java
@@ -51,7 +51,6 @@ public class XmlError implements java.io.Serializable {
     private final int _column;
     private int _offset = -1;
 
-    // TODO Never disposed?
     private transient XmlCursor _cursor;
 
     /**

--- a/src/main/java/org/apache/xmlbeans/XmlError.java
+++ b/src/main/java/org/apache/xmlbeans/XmlError.java
@@ -51,6 +51,7 @@ public class XmlError implements java.io.Serializable {
     private final int _column;
     private int _offset = -1;
 
+    // TODO Never disposed?
     private transient XmlCursor _cursor;
 
     /**

--- a/src/main/java/org/apache/xmlbeans/XmlError.java
+++ b/src/main/java/org/apache/xmlbeans/XmlError.java
@@ -104,22 +104,20 @@ public class XmlError implements java.io.Serializable {
             // Hunt down the line/column/offset
             source = cursor.documentProperties().getSourceName();
 
-            XmlCursor c = cursor.newCursor();
+            try (XmlCursor c = cursor.newCursor()) {
+                XmlLineNumber ln =
+                    (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
 
-            XmlLineNumber ln =
-                (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+                if (ln == null) {
+                    ln = (XmlLineNumber) c.toPrevBookmark(XmlLineNumber.class);
+                }
 
-            if (ln == null) {
-                ln = (XmlLineNumber) c.toPrevBookmark(XmlLineNumber.class);
+                if (ln != null) {
+                    line = ln.getLine();
+                    column = ln.getColumn();
+                    offset = ln.getOffset();
+                }
             }
-
-            if (ln != null) {
-                line = ln.getLine();
-                column = ln.getColumn();
-                offset = ln.getOffset();
-            }
-
-            c.dispose();
         }
 
         _message = message;

--- a/src/main/java/org/apache/xmlbeans/impl/inst2xsd/RussianDollStrategy.java
+++ b/src/main/java/org/apache/xmlbeans/impl/inst2xsd/RussianDollStrategy.java
@@ -38,25 +38,27 @@ public class RussianDollStrategy
 
     public void processDoc(XmlObject[] instances, Inst2XsdOptions options, TypeSystemHolder typeSystemHolder) {
         for (XmlObject instance : instances) {
-            XmlCursor xc = instance.newCursor();
-            // xc on start doc
+            try (XmlCursor xc = instance.newCursor()) {
+                // xc on start doc
 
-            StringBuilder comment = new StringBuilder();
+                StringBuilder comment = new StringBuilder();
 
-            while (!xc.isStart()) {
-                xc.toNextToken();
-                if (xc.isComment()) {
-                    comment.append(xc.getTextValue());
-                } else if (xc.isEnddoc()) {
-                    return;
+                while (!xc.isStart()) {
+                    xc.toNextToken();
+                    if (xc.isComment()) {
+                        comment.append(xc.getTextValue());
+                    } else if (xc.isEnddoc()) {
+                        return;
+                    }
                 }
+
+                // xc now on the root element
+
+                Element withElem = processElement(xc, comment.toString(), options, typeSystemHolder);
+                withElem.setGlobal(true);
+
+                addGlobalElement(withElem, typeSystemHolder, options);
             }
-            // xc now on the root element
-
-            Element withElem = processElement(xc, comment.toString(), options, typeSystemHolder);
-            withElem.setGlobal(true);
-
-            addGlobalElement(withElem, typeSystemHolder, options);
         }
     }
 

--- a/src/main/java/org/apache/xmlbeans/impl/inst2xsd/RussianDollStrategy.java
+++ b/src/main/java/org/apache/xmlbeans/impl/inst2xsd/RussianDollStrategy.java
@@ -164,27 +164,27 @@ public class RussianDollStrategy
         } else {
             // simple content
             // hack workaround for being able to call xc.getNamespaceForPrefix()
-            XmlCursor xcForNamespaces = xc.newCursor();
-            xcForNamespaces.toParent();
+            try (XmlCursor xcForNamespaces = xc.newCursor()) {
+                xcForNamespaces.toParent();
 
-            if (attributes.size() > 0) {
-                elemType.setContentType(Type.COMPLEX_TYPE_SIMPLE_CONTENT);
+                if (attributes.size() > 0) {
+                    elemType.setContentType(Type.COMPLEX_TYPE_SIMPLE_CONTENT);
 
-                Type extendedType = Type.createNamedType(
-                    processSimpleContentType(textBuff.toString(), options, xcForNamespaces), Type.SIMPLE_TYPE_SIMPLE_CONTENT);
-                elemType.setExtensionType(extendedType);
+                    Type extendedType = Type.createNamedType(
+                        processSimpleContentType(textBuff.toString(), options, xcForNamespaces), Type.SIMPLE_TYPE_SIMPLE_CONTENT);
+                    elemType.setExtensionType(extendedType);
 
-                processAttributesInComplexType(elemType, attributes);
-            } else {
-                elemType.setContentType(Type.SIMPLE_TYPE_SIMPLE_CONTENT);
-                elemType.setName(processSimpleContentType(textBuff.toString(), options, xcForNamespaces));
+                    processAttributesInComplexType(elemType, attributes);
+                } else {
+                    elemType.setContentType(Type.SIMPLE_TYPE_SIMPLE_CONTENT);
+                    elemType.setName(processSimpleContentType(textBuff.toString(), options, xcForNamespaces));
 
-                // add enumeration value
-                String enumValue = XmlString.type.getName().equals(elemType.getName()) ? textBuff.toString() : collapsedText;
-                elemType.addEnumerationValue(enumValue, xcForNamespaces);
+                    // add enumeration value
+                    String enumValue = XmlString.type.getName().equals(elemType.getName()) ? textBuff.toString() : collapsedText;
+                    elemType.addEnumerationValue(enumValue, xcForNamespaces);
+                }
+                // end hack
             }
-
-            xcForNamespaces.dispose(); // end hack
         }
 
         checkIfReferenceToGlobalTypeIsNeeded(element, typeSystemHolder, options);
@@ -267,13 +267,13 @@ public class RussianDollStrategy
 
         attribute.setName(attName);
 
-        XmlCursor parent = xc.newCursor();
-        parent.toParent();
+        Type simpleContentType;
+        try (XmlCursor parent = xc.newCursor()) {
+            parent.toParent();
 
-        Type simpleContentType = Type.createNamedType(
-            processSimpleContentType(xc.getTextValue(), options, parent), Type.SIMPLE_TYPE_SIMPLE_CONTENT);
-
-        parent.dispose();
+            simpleContentType = Type.createNamedType(
+                processSimpleContentType(xc.getTextValue(), options, parent), Type.SIMPLE_TYPE_SIMPLE_CONTENT);
+        }
 
         attribute.setType(simpleContentType);
 

--- a/src/main/java/org/apache/xmlbeans/impl/inst2xsd/util/TypeSystemHolder.java
+++ b/src/main/java/org/apache/xmlbeans/impl/inst2xsd/util/TypeSystemHolder.java
@@ -234,10 +234,11 @@ public class TypeSystemHolder
                 XmlQName xqname = XmlQName.Factory.newValue(value);
 
                 org.apache.xmlbeans.impl.xb.xsdschema.NoFixedFacet enumSElem = restriction.addNewEnumeration();
-                XmlCursor xc  = enumSElem.newCursor();
 
-                String newPrefix = xc.prefixForNamespace(value.getNamespaceURI());
-                xc.dispose();
+                String newPrefix;
+                try (XmlCursor xc  = enumSElem.newCursor()) {
+                    newPrefix = xc.prefixForNamespace(value.getNamespaceURI());
+                }
 
                 enumSElem.setValue( XmlQName.Factory.newValue(
                     new QName(value.getNamespaceURI(), value.getLocalPart(), newPrefix)));

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaAnnotationImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaAnnotationImpl.java
@@ -85,7 +85,7 @@ public class SchemaAnnotationImpl implements SchemaAnnotation
             for (int i = 0; i <  n; i++)
             {
                 String doc = _documentationAsXml[i];
-                try 
+                try
                 {
                     _documentation[i] = DocumentationDocument.Factory.
                         parse(doc).getDocumentation();
@@ -154,7 +154,7 @@ public class SchemaAnnotationImpl implements SchemaAnnotation
             // Now the attributes on the annotation element
             addNoSchemaAttributes(ann, attrArray);
         }
-        
+
         result._attributes =
             (AttributeImpl[]) attrArray.toArray(new AttributeImpl[attrArray.size()]);
         return result;

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaAnnotationImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaAnnotationImpl.java
@@ -162,33 +162,33 @@ public class SchemaAnnotationImpl implements SchemaAnnotation
 
     private static void addNoSchemaAttributes(XmlObject elem, List attrList)
     {
-        XmlCursor cursor = elem.newCursor();
-        boolean hasAttributes = cursor.toFirstAttribute();
-        while (hasAttributes)
-        {
-            QName name = cursor.getName();
-            String namespaceURI = name.getNamespaceURI();
-            if ("".equals(namespaceURI) ||
-                "http://www.w3.org/2001/XMLSchema".equals(namespaceURI))
-                ; // no nothing
-            else
+        try (XmlCursor cursor = elem.newCursor()) {
+            boolean hasAttributes = cursor.toFirstAttribute();
+            while (hasAttributes)
             {
-                String attValue = cursor.getTextValue();
-                String valUri;
-                String prefix;
-                if (attValue.indexOf(':') > 0)
-                    prefix = attValue.substring(0, attValue.indexOf(':'));
+                QName name = cursor.getName();
+                String namespaceURI = name.getNamespaceURI();
+                if ("".equals(namespaceURI) ||
+                    "http://www.w3.org/2001/XMLSchema".equals(namespaceURI))
+                    ; // no nothing
                 else
-                    prefix = "";
-                cursor.push();
-                cursor.toParent();
-                valUri = cursor.namespaceForPrefix(prefix);
-                cursor.pop();
-                attrList.add(new AttributeImpl(name, attValue, valUri)); //add the attribute
+                {
+                    String attValue = cursor.getTextValue();
+                    String valUri;
+                    String prefix;
+                    if (attValue.indexOf(':') > 0)
+                        prefix = attValue.substring(0, attValue.indexOf(':'));
+                    else
+                        prefix = "";
+                    cursor.push();
+                    cursor.toParent();
+                    valUri = cursor.namespaceForPrefix(prefix);
+                    cursor.pop();
+                    attrList.add(new AttributeImpl(name, attValue, valUri)); //add the attribute
+                }
+                hasAttributes = cursor.toNextAttribute();
             }
-            hasAttributes = cursor.toNextAttribute();
         }
-        cursor.dispose();
     }
 
     private SchemaAnnotationImpl(SchemaContainer c)

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaParticleImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaParticleImpl.java
@@ -307,8 +307,9 @@ public class SchemaParticleImpl implements SchemaParticle {
                         Documentation[] docArray = a.getDocumentationArray();
                         StringBuilder sb = new StringBuilder();
                         for (Documentation documentation : docArray) {
-                            XmlCursor c = documentation.newCursor();
-                            sb.append(c.getTextValue());
+                            try (XmlCursor c = documentation.newCursor()) {
+                                sb.append(c.getTextValue());
+                            }
                         }
                         return sb.toString();
                     }

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeImpl.java
@@ -2419,13 +2419,10 @@ public final class SchemaTypeImpl implements SchemaType, TypeStoreUserFactory {
 
         StringBuilder docBody = new StringBuilder();
         for (Documentation documentation : ann.getDocumentationArray()) {
-            XmlCursor c = documentation.newCursor();
-            try {
+            try (XmlCursor c = documentation.newCursor()) {
                 if (c.getChars() != null) {
                     docBody.append(c.getTextValue());
                 }
-            } finally {
-                c.dispose();
             }
         }
         return docBody.toString();

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscComplexTypeResolver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscComplexTypeResolver.java
@@ -48,9 +48,7 @@ public class StscComplexTypeResolver {
     }
 
     static Schema getSchema(XmlObject o) {
-        XmlCursor c = o.newCursor();
-
-        try {
+        try (XmlCursor c = o.newCursor()) {
             while (c.toParent()) {
                 o = c.getObject();
 
@@ -58,8 +56,6 @@ public class StscComplexTypeResolver {
                     return (Schema) o;
                 }
             }
-        } finally {
-            c.dispose();
         }
 
         return null;
@@ -1246,22 +1242,22 @@ public class StscComplexTypeResolver {
         }
 
         if (hasChildren) {
-            XmlCursor cur = parseTree.newCursor();
             List<SchemaParticle> accumulate = new ArrayList<>();
-            for (boolean more = cur.toFirstChild(); more; more = cur.toNextSibling()) {
-                int code = translateParticleCode(cur.getName());
-                if (code == 0) {
-                    continue;
+            try (XmlCursor cur = parseTree.newCursor()) {
+                for (boolean more = cur.toFirstChild(); more; more = cur.toNextSibling()) {
+                    int code = translateParticleCode(cur.getName());
+                    if (code == 0) {
+                        continue;
+                    }
+                    addMinusPointlessParticles(accumulate,
+                        translateContentModel(outerType,
+                            cur.getObject(), targetNamespace, chameleon,
+                            elemFormDefault, attFormDefault, code,
+                            anonymousTypes, elementModel, true, redefinitionFor),
+                        sPart.getParticleType());
                 }
-                addMinusPointlessParticles(accumulate,
-                    translateContentModel(outerType,
-                        cur.getObject(), targetNamespace, chameleon,
-                        elemFormDefault, attFormDefault, code,
-                        anonymousTypes, elementModel, true, redefinitionFor),
-                    sPart.getParticleType());
             }
             sPart.setParticleChildren(accumulate.toArray(new SchemaParticle[0]));
-            cur.dispose();
         }
 
 

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscTranslator.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscTranslator.java
@@ -697,13 +697,14 @@ public class StscTranslator {
     }
 
     static FormChoice findElementFormDefault(XmlObject obj) {
-        XmlCursor cur = obj.newCursor();
-        while (cur.getObject().schemaType() != Schema.type) {
-            if (!cur.toParent()) {
-                return null;
+        try (XmlCursor cur = obj.newCursor()) {
+            while (cur.getObject().schemaType() != Schema.type) {
+                if (!cur.toParent()) {
+                    return null;
+                }
             }
+            return ((Schema) cur.getObject()).xgetElementFormDefault();
         }
-        return ((Schema) cur.getObject()).xgetElementFormDefault();
     }
 
     public static boolean uriMatch(String s1, String s2) {
@@ -1271,13 +1272,14 @@ public class StscTranslator {
     }
 
     static FormChoice findAttributeFormDefault(XmlObject obj) {
-        XmlCursor cur = obj.newCursor();
-        while (cur.getObject().schemaType() != Schema.type) {
-            if (!cur.toParent()) {
-                return null;
+        try (XmlCursor cur = obj.newCursor()) {
+            while (cur.getObject().schemaType() != Schema.type) {
+                if (!cur.toParent()) {
+                    return null;
+                }
             }
+            return ((Schema) cur.getObject()).xgetAttributeFormDefault();
         }
-        return ((Schema) cur.getObject()).xgetAttributeFormDefault();
     }
 
     static SchemaLocalAttributeImpl translateAttribute(
@@ -1552,7 +1554,10 @@ public class StscTranslator {
 
 
     private static Object getUserData(XmlObject pos) {
-        XmlCursor.XmlBookmark b = pos.newCursor().getBookmark(SchemaBookmark.class);
+        XmlCursor.XmlBookmark b;
+        try (XmlCursor c = pos.newCursor()) {
+            b = c.getBookmark(SchemaBookmark.class);
+        }
         if (b instanceof SchemaBookmark) {
             return ((SchemaBookmark) b).getValue();
         } else {

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscTranslator.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscTranslator.java
@@ -993,9 +993,10 @@ public class StscTranslator {
         }
 
         SOAPArrayType wat = null;
-        XmlCursor c = xsdElt.newCursor();
-        String arrayType = c.getAttributeText(WSDL_ARRAYTYPE_NAME);
-        c.dispose();
+        String arrayType;
+        try (XmlCursor c = xsdElt.newCursor()) {
+            arrayType = c.getAttributeText(WSDL_ARRAYTYPE_NAME);
+        }
         if (arrayType != null) {
             try {
                 wat = new SOAPArrayType(arrayType, new NamespaceContext(xsdElt));
@@ -1206,13 +1207,12 @@ public class StscTranslator {
         ic.setUserData(getUserData(parseIC));
 
         // Set the ns map
-        XmlCursor c = parseIC.newCursor();
         Map<String, String> nsMap = new HashMap<>();
-
-        c.getAllNamespaces(nsMap);
+        try (XmlCursor c = parseIC.newCursor()) {
+            c.getAllNamespaces(nsMap);
+        }
         nsMap.remove(""); // Remove the default mapping. This cannot be used by the xpath expressions.
         ic.setNSMap(nsMap);
-        c.dispose();
 
         String[] fields = new String[fieldElts.length];
         for (int j = 0; j < fields.length; j++) {
@@ -1461,9 +1461,10 @@ public class StscTranslator {
         }
 
         SOAPArrayType wat = null;
-        XmlCursor c = xsdAttr.newCursor();
-        String arrayType = c.getAttributeText(WSDL_ARRAYTYPE_NAME);
-        c.dispose();
+        String arrayType;
+        try (XmlCursor c = xsdAttr.newCursor()) {
+            arrayType = c.getAttributeText(WSDL_ARRAYTYPE_NAME);
+        }
         if (arrayType != null) {
             try {
                 wat = new SOAPArrayType(arrayType, new NamespaceContext(xsdAttr));
@@ -1560,10 +1561,9 @@ public class StscTranslator {
     }
 
     private static boolean isEmptySchema(Schema schema) {
-        XmlCursor cursor = schema.newCursor();
-        boolean result = !cursor.toFirstChild();
-        cursor.dispose();
-        return result;
+        try (XmlCursor cursor = schema.newCursor()) {
+            return !cursor.toFirstChild();
+        }
     }
 
     private static boolean isReservedTypeName(QName name) {

--- a/src/main/java/org/apache/xmlbeans/impl/store/Cursor.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Cursor.java
@@ -201,7 +201,7 @@ public final class Cursor implements XmlCursor, ChangeListener {
     // change from a phantom ref to a soft/weak ref so I can know what
     // to do when I dequeue from the old q.
 
-    public void _close() {
+    public void _dispose() {
         _cur.release();
         _cur = null;
     }
@@ -1908,7 +1908,7 @@ public final class Cursor implements XmlCursor, ChangeListener {
     @Override
     public void close() {
         if (_cur != null) {
-            syncWrap(this::_close);
+            syncWrap(this::_dispose);
         }
     }
 

--- a/src/main/java/org/apache/xmlbeans/impl/store/Cursor.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Cursor.java
@@ -201,7 +201,7 @@ public final class Cursor implements XmlCursor, ChangeListener {
     // change from a phantom ref to a soft/weak ref so I can know what
     // to do when I dequeue from the old q.
 
-    public void _dispose() {
+    public void _close() {
         _cur.release();
         _cur = null;
     }
@@ -614,10 +614,9 @@ public final class Cursor implements XmlCursor, ChangeListener {
 
         boolean seenElement = false;
 
-        XmlCursor c = newCursor();
-        int token = c.toNextToken().intValue();
+        try (XmlCursor c = newCursor()) {
+            int token = c.toNextToken().intValue();
 
-        try {
             LOOP:
             for (; ; ) {
                 switch (token) {
@@ -655,8 +654,6 @@ public final class Cursor implements XmlCursor, ChangeListener {
                         break LOOP;
                 }
             }
-        } finally {
-            c.dispose();
         }
 
         return !seenElement;
@@ -1908,10 +1905,17 @@ public final class Cursor implements XmlCursor, ChangeListener {
         return _cur._locale.noSync();
     }
 
-    public void dispose() {
+    @Override
+    public void close() {
         if (_cur != null) {
-            syncWrap(this::_dispose);
+            syncWrap(this::_close);
         }
+    }
+
+    @Override
+    @Deprecated
+    public void dispose() {
+        close();
     }
 
     public Object monitor() {

--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCopy.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCopy.java
@@ -15,7 +15,6 @@
 
 package org.apache.xmlbeans.impl.tool;
 
-import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptions;
 import org.apache.xmlbeans.impl.common.IOUtil;
@@ -164,8 +163,6 @@ public class SchemaCopy {
         try {
             URL sourceURL = source.toURL();
             XmlObject xobj = XmlObject.Factory.parse(sourceURL, loadOptions);
-            XmlCursor xcur = xobj.newCursor();
-            xcur.toFirstChild();
 
             Map<URI,URI> result = new LinkedHashMap<>();
 

--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaResourceManager.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaResourceManager.java
@@ -98,7 +98,7 @@ public class SchemaResourceManager extends BaseSchemaResourceManager
             System.exit(0);
             return;
         }
-        
+
         args = cl.args();
 
         boolean sync = (cl.getOpt("sync") != null);

--- a/src/main/java/org/apache/xmlbeans/impl/values/NamespaceContext.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/NamespaceContext.java
@@ -141,13 +141,13 @@ public class NamespaceContext implements PrefixResolver
                 if (obj instanceof TypeStoreUser)
                     return ((TypeStoreUser)obj).get_store().getNamespaceForPrefix(prefix);
 
-                XmlCursor cur = ((XmlObject)_obj).newCursor();
-                if (cur != null)
-                {
-                    if (cur.currentTokenType() == XmlCursor.TokenType.ATTR)
-                        cur.toParent();
-                    try { return cur.namespaceForPrefix(prefix); }
-                    finally { cur.dispose(); }
+                try (XmlCursor cur = ((XmlObject)_obj).newCursor()) {
+                    if (cur != null)
+                    {
+                        if (cur.currentTokenType() == XmlCursor.TokenType.ATTR)
+                            cur.toParent();
+                        return cur.namespaceForPrefix(prefix);
+                    }
                 }
             }
             

--- a/src/main/java/org/apache/xmlbeans/impl/values/NamespaceContext.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/NamespaceContext.java
@@ -109,7 +109,7 @@ public class NamespaceContext implements PrefixResolver
     {
         getNamespaceContextStack().push(next);
     }
-            
+
     public static void pop()
     {
         NamespaceContextStack nsContextStack = getNamespaceContextStack();
@@ -128,7 +128,7 @@ public class NamespaceContext implements PrefixResolver
     {
         if (prefix != null && prefix.equals("xml"))
             return "http://www.w3.org/XML/1998/namespace";
-        
+
         switch (_code)
         {
             case XML_OBJECT:
@@ -150,19 +150,19 @@ public class NamespaceContext implements PrefixResolver
                     }
                 }
             }
-            
+
             case MAP:
                 return (String)((Map)_obj).get(prefix);
-                
+
             case TYPE_STORE:
                 return ((TypeStore)_obj).getNamespaceForPrefix(prefix);
-                
+
             case START_ELEMENT:
                 return ((StartElement)_obj).getNamespaceUri(prefix);
-                
+
             case RESOLVER:
                 return ((PrefixResolver)_obj).getNamespaceForPrefix(prefix);
-                
+
             default:
                 assert false : "Improperly initialized NamespaceContext.";
                 return null;

--- a/src/main/java/org/apache/xmlbeans/impl/values/XmlComplexContentImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/XmlComplexContentImpl.java
@@ -356,6 +356,7 @@ public class XmlComplexContentImpl extends XmlObjectBase {
                     ((XmlObjectBase) user).set(sources[j]);
                 }
                 for (i++, j++; i < sources.length; i++, j++) {
+                    // Cursor is implicitly closed
                     XmlCursor c = sources[i].isImmutable() ? null : sources[i].newCursor();
                     if (c != null && c.toParent() && c.getObject() == this) {
                         c.close();

--- a/src/main/java/org/apache/xmlbeans/impl/values/XmlComplexContentImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/XmlComplexContentImpl.java
@@ -335,12 +335,11 @@ public class XmlComplexContentImpl extends XmlObjectBase {
             if (sources[i].isImmutable()) {
                 continue;
             }
-            XmlCursor c = sources[i].newCursor();
-            if (c.toParent() && c.getObject() == this) {
-                c.dispose();
-                break;
+            try (XmlCursor c = sources[i].newCursor()) {
+                if (c.toParent() && c.getObject() == this) {
+                    break;
+                }
             }
-            c.dispose();
         }
         if (i < sources.length) {
             TypeStoreUser current = (set == null) ? store.find_element_user(elemName, 0) : store.find_element_user(set, 0);
@@ -359,7 +358,7 @@ public class XmlComplexContentImpl extends XmlObjectBase {
                 for (i++, j++; i < sources.length; i++, j++) {
                     XmlCursor c = sources[i].isImmutable() ? null : sources[i].newCursor();
                     if (c != null && c.toParent() && c.getObject() == this) {
-                        c.dispose();
+                        c.close();
                         current = (set == null) ? store.find_element_user(elemName, j) : store.find_element_user(set, j);
                         if (current != sources[i]) {
                             // Fall back to the general case
@@ -367,7 +366,7 @@ public class XmlComplexContentImpl extends XmlObjectBase {
                         }
                     } else {
                         if (c != null) {
-                            c.dispose();
+                            c.close();
                         }
                         // Insert before the current element
                         TypeStoreUser user = (set == null) ? store.insert_element_user(elemName, j) : store.insert_element_user(set, elemName, j);

--- a/src/main/java/org/apache/xmlbeans/impl/values/XmlObjectBase.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/XmlObjectBase.java
@@ -122,11 +122,8 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
     }
 
     public XmlDocumentProperties documentProperties() {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             return cur.documentProperties();
-        } finally {
-            cur.dispose();
         }
     }
 
@@ -135,11 +132,8 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
     }
 
     public XMLStreamReader newXMLStreamReader(XmlOptions options) {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             return cur.newXMLStreamReader(makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
@@ -148,11 +142,8 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
     }
 
     public InputStream newInputStream(XmlOptions options) {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             return cur.newInputStream(makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
@@ -161,20 +152,14 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
     }
 
     public Reader newReader(XmlOptions options) {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             return cur.newReader(makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
     public Node getDomNode() {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             return cur.getDomNode();
-        } finally {
-            cur.dispose();
         }
     }
 
@@ -183,47 +168,32 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
     }
 
     public Node newDomNode(XmlOptions options) {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             return cur.newDomNode(makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
     public void save(ContentHandler ch, LexicalHandler lh, XmlOptions options) throws SAXException {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             cur.save(ch, lh, makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
     public void save(File file, XmlOptions options) throws IOException {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             cur.save(file, makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
     public void save(OutputStream os, XmlOptions options) throws IOException {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             cur.save(os, makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
     public void save(Writer w, XmlOptions options) throws IOException {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             cur.save(w, makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
@@ -244,11 +214,8 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
     }
 
     public void dump() {
-        XmlCursor cur = newCursorForce();
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             cur.dump();
-        } finally {
-            cur.dispose();
         }
     }
 
@@ -485,13 +452,12 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
 
         // all user-level code; doesn't need to be synchronized
 
-        XmlCursor c = newCursor();
 
-        if (c == null) {
-            throw new XmlValueDisconnectedException();
-        }
+        try (XmlCursor c = newCursor()) {
+            if (c == null) {
+                throw new XmlValueDisconnectedException();
+            }
 
-        try {
             c.selectPath(path, options);
 
             if (!c.hasNextSelection()) {
@@ -510,8 +476,6 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
                     }
                 }
             }
-        } finally {
-            c.dispose();
         }
 
         return _typedArray(selections);
@@ -1478,12 +1442,8 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
     }
 
     public String xmlText(XmlOptions options) {
-        XmlCursor cur = newCursorForce();
-
-        try {
+        try (XmlCursor cur = newCursorForce()) {
             return cur.xmlText(makeInnerOptions(options));
-        } finally {
-            cur.dispose();
         }
     }
 
@@ -2636,8 +2596,7 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
      * Selects the contents of the children elements with the given name.
      */
     public XmlObject[] selectChildren(QName elementName) {
-        XmlCursor xc = this.newCursor();
-        try {
+        try (XmlCursor xc = this.newCursor()) {
             if (!xc.isContainer()) {
                 return EMPTY_RESULT;
             }
@@ -2656,8 +2615,6 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
             } else {
                 return result.toArray(EMPTY_RESULT);
             }
-        } finally {
-            xc.dispose();
         }
     }
 
@@ -2676,8 +2633,7 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
             throw new IllegalArgumentException();
         }
 
-        XmlCursor xc = this.newCursor();
-        try {
+        try (XmlCursor xc = this.newCursor()) {
             if (!xc.isContainer()) {
                 return EMPTY_RESULT;
             }
@@ -2699,8 +2655,6 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
             } else {
                 return result.toArray(EMPTY_RESULT);
             }
-        } finally {
-            xc.dispose();
         }
     }
 
@@ -2708,9 +2662,7 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
      * Selects the content of the attribute with the given name.
      */
     public XmlObject selectAttribute(QName attributeName) {
-        XmlCursor xc = this.newCursor();
-
-        try {
+        try (XmlCursor xc = this.newCursor()) {
             if (!xc.isContainer()) {
                 return null;
             }
@@ -2725,8 +2677,6 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
                 while (xc.toNextAttribute());
             }
             return null;
-        } finally {
-            xc.dispose();
         }
     }
 
@@ -2745,8 +2695,7 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
             throw new IllegalArgumentException();
         }
 
-        XmlCursor xc = this.newCursor();
-        try {
+        try (XmlCursor xc = this.newCursor()) {
             if (!xc.isContainer()) {
                 return EMPTY_RESULT;
             }
@@ -2768,8 +2717,6 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
             } else {
                 return result.toArray(EMPTY_RESULT);
             }
-        } finally {
-            xc.dispose();
         }
     }
 
@@ -2806,28 +2753,26 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
      * True if the object is at the root of the document.
      */
     private boolean isRootXmlObject() {
-        XmlCursor cur = newCursor();
-        if (cur == null) {
-            return false;
-        }
+        try (XmlCursor cur = newCursor()) {
+            if (cur == null) {
+                return false;
+            }
 
-        boolean result = !cur.toParent();
-        cur.dispose();
-        return result;
+            return !cur.toParent();
+        }
     }
 
     /**
      * Gets the root XmlObject for this document.
      */
     private XmlObject getRootXmlObject() {
-        XmlCursor cur = newCursor();
-        if (cur == null) {
-            return this;
+        try (XmlCursor cur = newCursor()) {
+            if (cur == null) {
+                return this;
+            }
+            cur.toStartDoc();
+            return cur.getObject();
         }
-        cur.toStartDoc();
-        XmlObject result = cur.getObject();
-        cur.dispose();
-        return result;
     }
 
     /**
@@ -3018,30 +2963,30 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
         }
 
         private int distanceToRoot() {
-            XmlCursor cur = _impl.newCursor();
             int count = 0;
-            while (!cur.toPrevToken().isNone()) {
-                if (!cur.currentTokenType().isNamespace()) {
-                    count += 1;
-                    // System.out.println("Count: " + count + " " + cur.currentTokenType().toString() + " " + QName.pretty(cur.getName()));
+            try (XmlCursor cur = _impl.newCursor()) {
+                while (!cur.toPrevToken().isNone()) {
+                    if (!cur.currentTokenType().isNamespace()) {
+                        count += 1;
+                        // System.out.println("Count: " + count + " " + cur.currentTokenType().toString() + " " + QName.pretty(cur.getName()));
+                    }
                 }
             }
-            cur.dispose();
             return count;
         }
 
         private XmlObject objectAtDistance(int count) {
-            XmlCursor cur = _root.newCursor();
-            while (count > 0) {
-                cur.toNextToken();
-                if (!cur.currentTokenType().isNamespace()) {
-                    count -= 1;
-                    // System.out.println("Count: " + count + " " + cur.currentTokenType().toString() + " " + QName.pretty(cur.getName()));
+            try (XmlCursor cur = _root.newCursor()) {
+                while (count > 0) {
+                    cur.toNextToken();
+                    if (!cur.currentTokenType().isNamespace()) {
+                        count -= 1;
+                        // System.out.println("Count: " + count + " " + cur.currentTokenType().toString() + " " + QName.pretty(cur.getName()));
+                    }
                 }
+                XmlObject result = cur.getObject();
+                return result;
             }
-            XmlObject result = cur.getObject();
-            cur.dispose();
-            return result;
         }
     }
 

--- a/src/main/java/org/apache/xmlbeans/impl/values/XmlObjectBase.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/XmlObjectBase.java
@@ -241,9 +241,10 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
 
         XmlObject x = XmlObject.Factory.newInstance(options);
 
-        XmlCursor c = x.newCursor();
-        c.toNextToken();
-        c.insertChars(value);
+        try (XmlCursor c = x.newCursor()) {
+            c.toNextToken();
+            c.insertChars(value);
+        }
 
         return x;
     }

--- a/src/main/java/org/apache/xmlbeans/impl/xpathgen/XPathGenerator.java
+++ b/src/main/java/org/apache/xmlbeans/impl/xpathgen/XPathGenerator.java
@@ -17,6 +17,7 @@ package org.apache.xmlbeans.impl.xpathgen;
 
 import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlCursor.TokenType;
+import org.apache.xmlbeans.XmlObject;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
@@ -146,23 +147,24 @@ public class XPathGenerator
     {
         int k = 0;
         int l = 0;
-        XmlCursor d = c.newCursor();
-        c.push();
-        c.toParent();
-        TokenType tt = c.toFirstContentToken();
-        while (!tt.isEnd())
-        {
-            if (tt.isText())
+        try (XmlCursor d = c.newCursor()) {
+            c.push();
+            c.toParent();
+            TokenType tt = c.toFirstContentToken();
+            while (!tt.isEnd())
             {
-                if (c.comparePosition(d) > 0)
-                    // We have moved after the initial position
-                    l++;
-                else
-                    k++;
+                if (tt.isText())
+                {
+                    if (c.comparePosition(d) > 0)
+                        // We have moved after the initial position
+                        l++;
+                    else
+                        k++;
+                }
+                else if (tt.isStart())
+                    c.toEndToken();
+                tt = c.toNextToken();
             }
-            else if (tt.isStart())
-                c.toEndToken();
-            tt = c.toNextToken();
         }
         c.pop();
         return l == 0 ? 0 : k;
@@ -191,33 +193,36 @@ public class XPathGenerator
                 return null;
             }
         };
-        XmlCursor c = org.apache.xmlbeans.XmlObject.Factory.parse(xml).newCursor();
-        c.toFirstContentToken(); // on <root>
-        c.toFirstContentToken(); // on <a>
-        c.toFirstChild();        // on <b>
-        c.toFirstChild();        // on <c>
-        c.push(); System.out.println(generateXPath(c, null, ns)); c.pop();
-        c.toNextSibling();
-        c.toNextSibling();       // on the last <c>
-        c.push(); System.out.println(generateXPath(c, null, ns)); c.pop();
-        XmlCursor d = c.newCursor();
-        d.toParent();
-        c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
-        d.toParent();
-        c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
-        c.toFirstContentToken(); // on text content of the last <c>
-        c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
-        c.toParent();
-        c.toPrevToken();         // on text content before the last <c>
-        c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
-        c.toParent();            // on <b>
-        c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
-        c.toFirstAttribute();    // on the "foo" attribute
-        c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
-        c.toParent();
-        c.toParent();
-        c.toNextToken();         // on the "xmlns:ns" attribute
-        c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
-        c.push(); System.out.println(generateXPath(c, null, ns)); c.pop();
+
+        try (XmlCursor c = XmlObject.Factory.parse(xml).newCursor()) {
+            c.toFirstContentToken(); // on <root>
+            c.toFirstContentToken(); // on <a>
+            c.toFirstChild();        // on <b>
+            c.toFirstChild();        // on <c>
+            c.push(); System.out.println(generateXPath(c, null, ns)); c.pop();
+            c.toNextSibling();
+            c.toNextSibling();       // on the last <c>
+            c.push(); System.out.println(generateXPath(c, null, ns)); c.pop();
+            try (XmlCursor d = c.newCursor()) {
+                d.toParent();
+                c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
+                d.toParent();
+                c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
+                c.toFirstContentToken(); // on text content of the last <c>
+                c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
+                c.toParent();
+                c.toPrevToken();         // on text content before the last <c>
+                c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
+                c.toParent();            // on <b>
+                c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
+                c.toFirstAttribute();    // on the "foo" attribute
+                c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
+                c.toParent();
+                c.toParent();
+                c.toNextToken();         // on the "xmlns:ns" attribute
+                c.push(); System.out.println(generateXPath(c, d, ns)); c.pop();
+            }
+            c.push(); System.out.println(generateXPath(c, null, ns)); c.pop();
+        }
     }
 }

--- a/src/main/java/org/apache/xmlbeans/impl/xpathgen/XPathGenerator.java
+++ b/src/main/java/org/apache/xmlbeans/impl/xpathgen/XPathGenerator.java
@@ -92,22 +92,22 @@ public class XPathGenerator
             return ".";
         assert node.isStart();
         QName name = node.getName();
-        XmlCursor d = node.newCursor();
-        if (!node.toParent())
-            return "/" + name;
         int elemIndex = 0, i = 1;
-        node.push();
-        if (!node.toChild(name))
-            throw new IllegalStateException("Must have at least one child with name: " + name);
-        do
-        {
-            if (node.isAtSamePositionAs(d))
-                elemIndex = i;
-            else
-                i++;
-        } while (node.toNextSibling(name));
-        node.pop();
-        d.dispose();
+        try (XmlCursor d = node.newCursor()) {
+            if (!node.toParent())
+                return "/" + name;
+            node.push();
+            if (!node.toChild(name))
+                throw new IllegalStateException("Must have at least one child with name: " + name);
+            do
+            {
+                if (node.isAtSamePositionAs(d))
+                    elemIndex = i;
+                else
+                    i++;
+            } while (node.toNextSibling(name));
+            node.pop();
+        }
         String pathToParent = generateInternal(node, context, nsctx);
         return  i == 1 ? pathToParent + '/' + qnameToString(name, nsctx) :
             pathToParent + '/' + qnameToString(name, nsctx) + '[' + elemIndex + ']';

--- a/src/main/java/org/apache/xmlbeans/impl/xsd2inst/SampleXmlUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/xsd2inst/SampleXmlUtil.java
@@ -990,10 +990,11 @@ public class SampleXmlUtil {
     }
 
     private static String formatQName(XmlCursor xmlc, QName qName) {
-        XmlCursor parent = xmlc.newCursor();
-        parent.toParent();
-        String prefix = parent.prefixForNamespace(qName.getNamespaceURI());
-        parent.dispose();
+        String prefix;
+        try (XmlCursor parent = xmlc.newCursor()) {
+            parent.toParent();
+            prefix = parent.prefixForNamespace(qName.getNamespaceURI());
+        }
         String name;
         if (prefix == null || prefix.length() == 0) {
             name = qName.getLocalPart();

--- a/src/main/java/org/apache/xmlbeans/impl/xsd2inst/SampleXmlUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/xsd2inst/SampleXmlUtil.java
@@ -50,12 +50,13 @@ public class SampleXmlUtil {
      */
     public static String createSampleForType(SchemaType sType) {
         XmlObject object = XmlObject.Factory.newInstance();
-        XmlCursor cursor = object.newCursor();
-        // Skip the document node
-        cursor.toNextToken();
-        // Using the type and the cursor, call the utility method to get a
-        // sample XML payload for that Schema element
-        new SampleXmlUtil(false).createSampleForType(sType, cursor);
+        try (XmlCursor cursor = object.newCursor()) {
+            // Skip the document node
+            cursor.toNextToken();
+            // Using the type and the cursor, call the utility method to get a
+            // sample XML payload for that Schema element
+            new SampleXmlUtil(false).createSampleForType(sType, cursor);
+        }
         // Cursor now contains the sample payload
         // Pretty print the result.  Note that the cursor is positioned at the
         // end of the doc so we use the original xml object that the cursor was
@@ -75,12 +76,13 @@ public class SampleXmlUtil {
     public static String createSampleForType(SchemaField element) {
         SchemaType sType = element.getType();
         XmlObject object = XmlObject.Factory.newInstance();
-        XmlCursor cursor = object.newCursor();
-        // Skip the document node
-        cursor.toNextToken();
-        // Using the type and the cursor, call the utility method to get a
-        // sample XML payload for that Schema element
-        new SampleXmlUtil(false).createSampleForType(sType, cursor);
+        try (XmlCursor cursor = object.newCursor()) {
+            // Skip the document node
+            cursor.toNextToken();
+            // Using the type and the cursor, call the utility method to get a
+            // sample XML payload for that Schema element
+            new SampleXmlUtil(false).createSampleForType(sType, cursor);
+        }
         // Cursor now contains the sample payload
         // Pretty print the result.  Note that the cursor is positioned at the
         // end of the doc so we use the original xml object that the cursor was

--- a/src/test/java/ValidatingXSRTests/checkin/ValidatingXMLStreamReaderTests.java
+++ b/src/test/java/ValidatingXSRTests/checkin/ValidatingXMLStreamReaderTests.java
@@ -104,10 +104,11 @@ public class ValidatingXMLStreamReaderTests {
     public void testValidateGlobalAtt1() throws XMLStreamException
     {
         XmlObject xo = XmlObject.Factory.newInstance();
-        XmlCursor xc = xo.newCursor();
-        xc.toNextToken();
+        try (XmlCursor xc = xo.newCursor()) {
+            xc.toNextToken();
 
-        xc.insertAttributeWithValue("price", URI_NUMERALS, "23.5");
+            xc.insertAttributeWithValue("price", URI_NUMERALS, "23.5");
+        }
 
         XMLStreamReader xsr = xo.newXMLStreamReader(new XmlOptions().setSaveOuter());
         Collection errors = new ArrayList();

--- a/src/test/java/compile/scomp/checkin/CompilationTests.java
+++ b/src/test/java/compile/scomp/checkin/CompilationTests.java
@@ -266,8 +266,10 @@ public class CompilationTests {
             }
         assertTrue("Could not find the \"person\" complex type", found);
         // Set the bookmark
-        SchemaBookmark sb = new SchemaBookmark("MyBookmark");
-        cTypes[i].newCursor().setBookmark(sb);
+        try (XmlCursor c = cTypes[i].newCursor()) {
+            SchemaBookmark sb = new SchemaBookmark("MyBookmark");
+            c.setBookmark(sb);
+        }
         // Compile it into STS
         SchemaTypeSystem sts = XmlBeans.compileXsd(new XmlObject[]{parsed},
             XmlBeans.getBuiltinTypeSystem(), null);

--- a/src/test/java/dom/checkin/DirtyCacheTests.java
+++ b/src/test/java/dom/checkin/DirtyCacheTests.java
@@ -55,9 +55,10 @@ public class DirtyCacheTests {
         testElt.setChild3(new BigInteger("1"));
         testElt.setChild1(new BigInteger("0"));
 
-        XmlCursor cur = testElt.newCursor();
-        cur.toFirstContentToken();
-        cur.insertChars("Random mixed content");
+        try (XmlCursor cur = testElt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.insertChars("Random mixed content");
+        }
         Node n = o.getDomNode();
         n = n.getFirstChild();
         n = n.getFirstChild();

--- a/src/test/java/dom/checkin/DomTests.java
+++ b/src/test/java/dom/checkin/DomTests.java
@@ -102,14 +102,14 @@ public class DomTests {
 
         XmlObject x = XmlObject.Factory.parse(xx);
 
-        XmlCursor c = x.newCursor();
+        try (XmlCursor c = x.newCursor()) {
+            for (; ;) {
+                Node n = c.newDomNode();
+                XmlObject.Factory.parse(n);
 
-        for (; ;) {
-            Node n = c.newDomNode();
-            XmlObject.Factory.parse(n);
-
-            if (c.toNextToken().isNone())
-                break;
+                if (c.toNextToken().isNone())
+                    break;
+            }
         }
     }
 }

--- a/src/test/java/dom/checkin/DomTests.java
+++ b/src/test/java/dom/checkin/DomTests.java
@@ -74,7 +74,7 @@ public class DomTests {
 //
 //        System.out.println( x.xmlText() );
 //    }
-    
+
     @Test
     public void testDom()
             throws Exception {

--- a/src/test/java/misc/checkin/RuntimeSchemaLoaderTest.java
+++ b/src/test/java/misc/checkin/RuntimeSchemaLoaderTest.java
@@ -68,23 +68,24 @@ public class RuntimeSchemaLoaderTest {
                         new QName("http://openuri.org/test/dyntest",
                                 "wrappedwildcard")),
                 result.schemaType());
-        XmlCursor cur = result.newCursor();
-        Assert.assertTrue("Should have a root element", cur.toFirstChild());
-        result = cur.getObject();
-        assertEquals(
-                "E=wrappedwildcard|D=wrappedwildcard@http://openuri.org/test/dyntest",
-                result.schemaType().toString());
-        assertEquals(
-                loader.findElement(
-                        new QName("http://openuri.org/test/dyntest",
-                                "wrappedwildcard"))
-                .getType(),
-                result.schemaType());
-        Assert.assertTrue("Should have a first child", cur.toFirstChild());
-        assertEquals(
-                new QName("http://www.w3.org/2001/XMLSchema", "schema"),
-                cur.getName());
-        XmlObject obj = cur.getObject();
-        assertEquals(Schema.type, obj.schemaType());
+        try (XmlCursor cur = result.newCursor()) {
+            Assert.assertTrue("Should have a root element", cur.toFirstChild());
+            result = cur.getObject();
+            assertEquals(
+                    "E=wrappedwildcard|D=wrappedwildcard@http://openuri.org/test/dyntest",
+                    result.schemaType().toString());
+            assertEquals(
+                    loader.findElement(
+                            new QName("http://openuri.org/test/dyntest",
+                                    "wrappedwildcard"))
+                    .getType(),
+                    result.schemaType());
+            Assert.assertTrue("Should have a first child", cur.toFirstChild());
+            assertEquals(
+                    new QName("http://www.w3.org/2001/XMLSchema", "schema"),
+                    cur.getName());
+            XmlObject obj = cur.getObject();
+            assertEquals(Schema.type, obj.schemaType());
+        }
     }
 }

--- a/src/test/java/misc/detailed/JiraRegression1_50Test.java
+++ b/src/test/java/misc/detailed/JiraRegression1_50Test.java
@@ -48,12 +48,12 @@ public class JiraRegression1_50Test extends JiraTestBase {
         XmlOptions options = new XmlOptions().setErrorListener(errors);
         try {
             myxmlobj = XmlObject.Factory.parse(xmlstringbuf.toString(), options);
-            XmlCursor cur = myxmlobj.newCursor();
-            XmlError xmlerr = XmlError.forObject("This is my custom error message", XmlError.SEVERITY_ERROR, myxmlobj);
+            try (XmlCursor cur = myxmlobj.newCursor()) {
+                XmlError xmlerr = XmlError.forObject("This is my custom error message", XmlError.SEVERITY_ERROR, myxmlobj);
 
-            // call an API on the cursor : verification of cursor not being disposed
-            System.out.println("Cursor Text Value: " + cur.getTextValue());
-
+                // call an API on the cursor : verification of cursor not being disposed
+                System.out.println("Cursor Text Value: " + cur.getTextValue());
+            }
         } catch (XmlException xme) {
             if (!xme.getErrors().isEmpty()) {
                 for (Iterator itr = xme.getErrors().iterator(); itr.hasNext();) {

--- a/src/test/java/misc/detailed/JiraRegression1_50Test.java
+++ b/src/test/java/misc/detailed/JiraRegression1_50Test.java
@@ -173,11 +173,11 @@ public class JiraRegression1_50Test extends JiraTestBase {
     public void test_jira_xmlbeans14() throws Exception {
         XmlObject xObj = XmlObject.Factory.parse("<Baz/>");
         // add element
-        XmlCursor xCursor = xObj.newCursor();
-        xCursor.toFirstContentToken();
-        xCursor.insertElementWithText(new QName("Some uri", "SomeName"), "SomeValue");
-        xCursor.insertElementWithText(new QName("Some uri", "SomeName1"), "SomeValue1");
-        xCursor.dispose();
+        try (XmlCursor xCursor = xObj.newCursor()) {
+            xCursor.toFirstContentToken();
+            xCursor.insertElementWithText(new QName("Some uri", "SomeName"), "SomeValue");
+            xCursor.insertElementWithText(new QName("Some uri", "SomeName1"), "SomeValue1");
+        }
 
         // debug
         xObj.save(System.out);

--- a/src/test/java/misc/detailed/JiraRegression50_100Test.java
+++ b/src/test/java/misc/detailed/JiraRegression50_100Test.java
@@ -513,9 +513,10 @@ public class JiraRegression50_100Test extends JiraTestBase
         //XmlObject[] resSet = xb81.selectPath("$this//MatchedRecord[TableName=\"ABC\"]/TableName");
         XmlObject[] resSet = xb81.selectPath(".//MatchedRecord[TableName=\"ABC\"]/TableName");
         assertEquals(resSet.length , 1);
-        XmlCursor cursor = xb81.newCursor();
-        //cursor.selectPath("$this//MatchedRecord[TableName=\"ABC\"]/TableName");
-        cursor.selectPath(".//MatchedRecord[TableName=\"ABC\"]/TableName");
+        try (XmlCursor cursor = xb81.newCursor()) {
+            //cursor.selectPath("$this//MatchedRecord[TableName=\"ABC\"]/TableName");
+            cursor.selectPath(".//MatchedRecord[TableName=\"ABC\"]/TableName");
+        }
     }
 
     /**
@@ -629,10 +630,11 @@ public class JiraRegression50_100Test extends JiraTestBase
         child.setQualifiedData(new QName(datanamespace, "IAmQualified"));
 
         // Add a schema location attribute to the doc element
-        XmlCursor c = root.newCursor();
-        c.toNextToken();
-        c.insertAttributeWithValue("schemaLocation", xsinamespace,
-                structnamespace + " " + schemaloc);
+        try (XmlCursor c = root.newCursor()) {
+            c.toNextToken();
+            c.insertAttributeWithValue("schemaLocation", xsinamespace,
+                    structnamespace + " " + schemaloc);
+        }
 
         //String expXML = doc.xmlText(options.setSavePrettyPrint())
         // save as XML text using the options

--- a/src/test/java/random/common/Random.java
+++ b/src/test/java/random/common/Random.java
@@ -438,13 +438,11 @@ public class Random implements Runnable {
     }
 
     private void setName() {
-        XmlCursor c = findObject().newCursor();
-
-        if (!c.isStartdoc()) {
-            c.setName(getQName());
+        try (XmlCursor c = findObject().newCursor()) {
+            if (!c.isStartdoc()) {
+                c.setName(getQName());
+            }
         }
-
-        c.dispose();
     }
 
     private void newDomNode() {

--- a/src/test/java/random/common/Random.java
+++ b/src/test/java/random/common/Random.java
@@ -118,7 +118,7 @@ public class Random implements Runnable {
                 _docs[d] = XmlObject.Factory.newInstance();
             }
 
-            _cursors = new ArrayList();
+            _cursors = new ArrayList<>();
 
             int nIterations = rnd(60000) + 5000;
 
@@ -136,6 +136,9 @@ public class Random implements Runnable {
                     }
                 }
             }
+
+            _cursors.forEach(XmlCursor::close);
+            _cursors = null;
         } catch (Throwable e) {
             System.err.println("Error on seed " + _seed);
             e.printStackTrace(System.err);
@@ -145,7 +148,7 @@ public class Random implements Runnable {
     private java.util.Random _rnd;
 
     private XmlObject[] _docs; // shared among threads!!
-    private ArrayList _cursors;
+    private ArrayList<XmlCursor> _cursors;
     private long _seed;
     private int _iter;
     private boolean _readonly;
@@ -171,7 +174,7 @@ public class Random implements Runnable {
             return c;
         }
 
-        return (XmlCursor) _cursors.get(rnd(n));
+        return _cursors.get(rnd(n));
     }
 
     private void iterate() throws Exception {
@@ -323,9 +326,9 @@ public class Random implements Runnable {
                 getObject();
                 break;
             case 7:
-                newCursor();
+                try (XmlCursor c = newCursor()) {
+                }
                 break;
-
             case 8:
                 validate();
                 break;
@@ -433,12 +436,12 @@ public class Random implements Runnable {
         getCursor().prevTokenType();
     }
 
-    private void newCursor() {
-        findObject().newCursor();
+    private XmlCursor newCursor() {
+        return findObject().newCursor();
     }
 
     private void setName() {
-        try (XmlCursor c = findObject().newCursor()) {
+        try (XmlCursor c = newCursor()) {
             if (!c.isStartdoc()) {
                 c.setName(getQName());
             }

--- a/src/test/java/scomp/attributes/detailed/AttrGroupTest.java
+++ b/src/test/java/scomp/attributes/detailed/AttrGroupTest.java
@@ -43,11 +43,12 @@ public class AttrGroupTest extends BaseCase {
         elt.setVersion(new BigDecimal(new BigInteger("10")));
         elt.setGlobalAttr(new BigDecimal(BigInteger.ONE));
         //add a wildcard attr: ##other, lax
-        XmlCursor cur = elt.newCursor();
-        //move to document element
-        cur.toNextToken();
-        cur.insertAttribute(new QName("http://org.apache.sample", "attr",
-                "pre"));
+        try (XmlCursor cur = elt.newCursor()) {
+            //move to document element
+            cur.toNextToken();
+            cur.insertAttribute(new QName("http://org.apache.sample", "attr",
+                    "pre"));
+        }
         String[] errExpected=new String[]{
             XmlErrorCodes
                 .ELEM_COMPLEX_TYPE_LOCALLY_VALID$MISSING_REQUIRED_ATTRIBUTE};

--- a/src/test/java/scomp/attributes/detailed/LocalAttrForm.java
+++ b/src/test/java/scomp/attributes/detailed/LocalAttrForm.java
@@ -20,6 +20,7 @@ import xbean.scomp.namespace.attributeFormDefault.AttributeUnqualifiedDocument;
 
 import javax.xml.namespace.QName;
 
+import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlErrorCodes;
 
 import static org.junit.Assert.assertTrue;
@@ -47,19 +48,16 @@ public class LocalAttrForm extends BaseCase{
             throw t;
         }
 
-        doc.getAttributeUnqualified().getLocalAttribute().
-                newCursor()
-                .setName(new QName(
-                        "http://xbean/scomp/namespace/AttributeFormDefault",
-                        "LocalAttribute"));
-         assertTrue( !doc.validate(validateOptions) );
+        try (XmlCursor c = doc.getAttributeUnqualified().getLocalAttribute().newCursor()) {
+            c.setName(new QName(
+                "http://xbean/scomp/namespace/AttributeFormDefault",
+                "LocalAttribute"));
+        }
+        assertTrue( !doc.validate(validateOptions) );
         System.out.println(doc.xmlText());
         showErrors();
         String[] errExpected = new String[]
         {XmlErrorCodes.ELEM_COMPLEX_TYPE_LOCALLY_VALID$NO_WILDCARD};
             assertTrue(compareErrorCodes(errExpected));
-        
-
-
     }
 }

--- a/src/test/java/scomp/contentType/complex/detailed/AnonymousTest.java
+++ b/src/test/java/scomp/contentType/complex/detailed/AnonymousTest.java
@@ -70,9 +70,10 @@ public class AnonymousTest extends BaseCase {
         assertEquals(5, testElt.getChild2().intValue());
         assertTrue(XmlInteger.Factory.parse("<xml-fragment>5</xml-fragment>")
             .valueEquals(testElt.xgetChild2()));
-        XmlCursor cur = testElt.newCursor();
-        cur.toFirstContentToken();
-        cur.insertChars("Random mixed content");
+        try (XmlCursor cur = testElt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.insertChars("Random mixed content");
+        }
         testElt.setChild3(new BigInteger("1"));
         assertEquals("<xml-fragment>Random mixed content" +
             "<child2>5</child2>" +

--- a/src/test/java/scomp/contentType/complex/detailed/ElementOnlyContentTest.java
+++ b/src/test/java/scomp/contentType/complex/detailed/ElementOnlyContentTest.java
@@ -79,9 +79,10 @@ public class ElementOnlyContentTest extends BaseCase {
         testElt.setChild2(new BigInteger("5"));
         testElt.setChild3(new BigInteger("1"));
         assertTrue(testElt.validate());
-        XmlCursor cur = testElt.newCursor();
-        cur.toFirstContentToken();
-        cur.insertChars("Random mixed content");
+        try (XmlCursor cur = testElt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.insertChars("Random mixed content");
+        }
         System.out.println(testElt.xmlText());
         assertTrue(!testElt.validate(validateOptions));
         showErrors();

--- a/src/test/java/scomp/contentType/complex/detailed/EmptyContentTest.java
+++ b/src/test/java/scomp/contentType/complex/detailed/EmptyContentTest.java
@@ -66,6 +66,6 @@ public class EmptyContentTest extends BaseCase {
 
         elt.unsetEmptyAttr();
         assertTrue(!elt.isSetEmptyAttr());
-        assertTrue(elt.validate());     
+        assertTrue(elt.validate());
     }
 }

--- a/src/test/java/scomp/contentType/complex/detailed/EmptyContentTest.java
+++ b/src/test/java/scomp/contentType/complex/detailed/EmptyContentTest.java
@@ -33,9 +33,10 @@ public class EmptyContentTest extends BaseCase {
         assertTrue(!elt.isSetEmptyAttr());
         elt.setEmptyAttr("foobar");
         assertTrue(elt.validate());
-        XmlCursor cur = elt.newCursor();
-        cur.toFirstContentToken();
-        cur.beginElement("foobarElt");
+        try (XmlCursor cur = elt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.beginElement("foobarElt");
+        }
         assertTrue(!elt.validate(validateOptions));
         showErrors();
         String[] errExpected = new String[]{

--- a/src/test/java/scomp/contentType/complex/detailed/MixedContentTest.java
+++ b/src/test/java/scomp/contentType/complex/detailed/MixedContentTest.java
@@ -70,8 +70,9 @@ public class MixedContentTest extends BaseCase {
         testElt = doc.addNewMixedType();
         assertNull(testElt.getChild1());
         assertNull(testElt.xgetChild1());
-        XmlCursor cur = testElt.newCursor();
-        cur.insertChars("Random mixed content");
+        try (XmlCursor cur = testElt.newCursor()) {
+            cur.insertChars("Random mixed content");
+        }
         assertTrue( !testElt.validate(validateOptions) );
         showErrors();
         String[] errExpected = new String[]{
@@ -98,15 +99,15 @@ public class MixedContentTest extends BaseCase {
             showErrors();
             throw t;
         }
-        XmlCursor cur = testElt.newCursor();
-        cur.toFirstContentToken();
-        cur.insertChars("Random mixed content");
-        //move past child1
-        cur.toNextToken();
-        cur.toNextToken();
-         cur.toNextToken();
-        cur.insertChars("Random mixed content1");
-        try {
+        try (XmlCursor cur = testElt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.insertChars("Random mixed content");
+            //move past child1
+            cur.toNextToken();
+            cur.toNextToken();
+            cur.toNextToken();
+            cur.insertChars("Random mixed content1");
+
             assertTrue(testElt.validate());
         }
         catch (Throwable t) {
@@ -125,38 +126,34 @@ public class MixedContentTest extends BaseCase {
         testElt.setChild2(new BigInteger("5"));
         testElt.setChild3(new BigInteger("1"));
         testElt.setChild1(new BigInteger("0"));
-        XmlCursor cur = testElt.newCursor();
-        cur.toFirstContentToken();
-        cur.insertChars("Random mixed content");
-        //move past child1
-        cur.toNextToken();
-        cur.toNextToken();
-         cur.toNextToken();
-        cur.insertChars("Random mixed content1");
-        try {
+        try (XmlCursor cur = testElt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.insertChars("Random mixed content");
+            //move past child1
+            cur.toNextToken();
+            cur.toNextToken();
+            cur.toNextToken();
+            cur.insertChars("Random mixed content1");
             assertTrue(testElt.validate(validateOptions));
-        }
-        catch (Throwable t) {
+            assertEquals("<xml-fragment>Random mixed content" +
+                    "<child1>0</child1>Random mixed content1<child2>5</child2>" +
+                    "<child3>1</child3></xml-fragment>",testElt.xmlText() );
+            //to child1
+            cur.toPrevToken();
+            cur.toPrevToken();
+            cur.toPrevToken();
+            cur.toPrevToken();
+            assertEquals(XmlCursor.TokenType.START, cur.currentTokenType());
+            assertTrue(cur.removeXml());
+            assertEquals(null,testElt.getChild1());
+
+            assertEquals("<xml-fragment>Random mixed content" +
+                    "Random mixed content1<child2>5</child2>" +
+                    "<child3>1</child3></xml-fragment>",testElt.xmlText() );
+        } catch (Throwable t) {
             showErrors();
             throw t;
         }
-        assertEquals("<xml-fragment>Random mixed content" +
-                "<child1>0</child1>Random mixed content1<child2>5</child2>" +
-                "<child3>1</child3></xml-fragment>",testElt.xmlText() );
-        //to child1
-        cur.toPrevToken();
-        cur.toPrevToken();
-         cur.toPrevToken();
-         cur.toPrevToken();
-        assertEquals(XmlCursor.TokenType.START, cur.currentTokenType());
-        assertTrue(cur.removeXml());
-         assertEquals(null,testElt.getChild1());
-
-       assertEquals("<xml-fragment>Random mixed content" +
-                "Random mixed content1<child2>5</child2>" +
-                "<child3>1</child3></xml-fragment>",testElt.xmlText() );
-       
-
     }
 
     /**

--- a/src/test/java/scomp/contentType/complex/detailed/NamedTest.java
+++ b/src/test/java/scomp/contentType/complex/detailed/NamedTest.java
@@ -71,9 +71,10 @@ public class NamedTest extends BaseCase {
         expected.setBigIntegerValue(new BigInteger("5"));
         assertTrue(expected.valueEquals(testElt.xgetChild2()));
 
-        XmlCursor cur = testElt.newCursor();
-        cur.toFirstContentToken();
-        cur.insertChars("Random mixed content");
+        try (XmlCursor cur = testElt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.insertChars("Random mixed content");
+        }
         testElt.setChild3(new BigInteger("1"));
         assertEquals("<xml-fragment>Random mixed content" +
                 "<child2>5</child2><child3>1</child3></xml-fragment>",

--- a/src/test/java/scomp/contentType/complex/modelGroup/detailed/ChoiceTest.java
+++ b/src/test/java/scomp/contentType/complex/modelGroup/detailed/ChoiceTest.java
@@ -69,12 +69,12 @@ public class ChoiceTest extends BaseCase {
         MixedChoiceT elt = doc.addNewMixedChoiceElt();
         assertTrue(!elt.isSetChild1());
         elt.setChild1(new BigInteger("10"));
-        XmlCursor cur = elt.newCursor();
-        assertEquals(XmlCursor.TokenType.START, cur.toFirstContentToken());
-        cur.toEndToken(); //past child one
-        cur.toNextToken();
-        cur.insertChars("foobar");
-        try {
+        try (XmlCursor cur = elt.newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, cur.toFirstContentToken());
+            cur.toEndToken(); //past child one
+            cur.toNextToken();
+            cur.insertChars("foobar");
+
             assertTrue(doc.validate(validateOptions));
         } catch (Throwable t) {
             showErrors();

--- a/src/test/java/scomp/derivation/extension/detailed/MixedContentExtension.java
+++ b/src/test/java/scomp/derivation/extension/detailed/MixedContentExtension.java
@@ -35,17 +35,18 @@ public class MixedContentExtension extends BaseCase {
         ExtendedMixedT elt = doc.addNewExtendedMixedElt();
         elt.setExtendedAttr("FOOBAR_val");
         elt.setChild1(new BigInteger("10"));
-        XmlCursor cur = elt.newCursor();
-        cur.toFirstContentToken();
-        cur.beginElement("Child2");
-        cur.toNextToken();
-        cur.insertChars("2");
-        elt.setChild3(BigInteger.ONE);
-        cur.toFirstContentToken();
-        cur.toEndToken();
-        cur.toNextToken();
-         cur.toNextToken();
-        cur.insertChars(" SOME CDATA HERE");
+        try (XmlCursor cur = elt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.beginElement("Child2");
+            cur.toNextToken();
+            cur.insertChars("2");
+            elt.setChild3(BigInteger.ONE);
+            cur.toFirstContentToken();
+            cur.toEndToken();
+            cur.toNextToken();
+            cur.toNextToken();
+            cur.insertChars(" SOME CDATA HERE");
+        }
         String resultStr=
                 "<com:ExtendedMixedElt extendedAttr=\"FOOBAR_val\" " +
                 "xmlns:com=\"http://xbean/scomp/derivation/ComplexExtension\">" +
@@ -78,18 +79,18 @@ public class MixedContentExtension extends BaseCase {
         ExtendedMixedT elt = doc.addNewExtendedMixedElt();
         elt.setExtendedAttr("FOOBAR_val");
         elt.setChild1(new BigInteger("10"));
-        XmlCursor cur = elt.newCursor();
-        cur.toEndToken();
-        cur.beginElement("child2");
-        cur.insertChars("2");
-        cur.toNextToken();
+        try (XmlCursor cur = elt.newCursor()) {
+            cur.toEndToken();
+            cur.beginElement("child2");
+            cur.insertChars("2");
+            cur.toNextToken();
 
-        cur.insertComment("My comment");
-        elt.setChild3(BigInteger.ONE);
-        cur.toFirstContentToken();
-        cur.toEndToken();
-         cur.insertChars("SOME CDATA HERE");
-        try {
+            cur.insertComment("My comment");
+            elt.setChild3(BigInteger.ONE);
+            cur.toFirstContentToken();
+            cur.toEndToken();
+            cur.insertChars("SOME CDATA HERE");
+
             assertTrue( doc.validate(validateOptions) );
         }
         catch (Throwable t) {

--- a/src/test/java/scomp/derivation/restriction/detailed/EmptyContentRestriction.java
+++ b/src/test/java/scomp/derivation/restriction/detailed/EmptyContentRestriction.java
@@ -47,10 +47,11 @@ public class EmptyContentRestriction extends BaseCase {
             showErrors();
             throw t;
         }
-        XmlCursor cur = elt.newCursor();
-        cur.toFirstContentToken();
-        cur.toNextToken();
-        cur.beginElement("foobar");
+        try (XmlCursor cur = elt.newCursor()) {
+            cur.toFirstContentToken();
+            cur.toNextToken();
+            cur.beginElement("foobar");
+        }
         assertEquals("<xml-fragment>" +
                 "<emt:RestrictedEmptyElt emptyAttr=\"myval\" " +
                 "xmlns:emt=\"http://xbean/scomp/derivation/Emtpy\"/>" +

--- a/src/test/java/scomp/derivation/restriction/detailed/MixedContentRestriction.java
+++ b/src/test/java/scomp/derivation/restriction/detailed/MixedContentRestriction.java
@@ -35,14 +35,13 @@ public class MixedContentRestriction extends BaseCase{
         elt.setChild1(new BigInteger("10"));
         elt.setChild2(BigInteger.ZERO);
         //insert text b/n the 2 elements
-        XmlCursor cur=elt.newCursor();
-        cur.toFirstContentToken();
-        assertTrue(cur.toNextSibling());
-        cur.insertChars("My chars");
-          try {
+        try (XmlCursor cur = elt.newCursor()) {
+            cur.toFirstContentToken();
+            assertTrue(cur.toNextSibling());
+            cur.insertChars("My chars");
+
             assertTrue( doc.validate(validateOptions));
-        }
-        catch (Throwable t) {
+        } catch (Throwable t) {
             showErrors();
             throw t;
         }
@@ -53,32 +52,30 @@ public class MixedContentRestriction extends BaseCase{
 
     @Test
     public void testRestrictedEltOnly() throws Throwable{
-       ElementOnlyEltDocument doc=ElementOnlyEltDocument.Factory.newInstance();
+        ElementOnlyEltDocument doc=ElementOnlyEltDocument.Factory.newInstance();
         RestrictedEltT elt=doc.addNewElementOnlyElt();
         assertTrue( !elt.isSetChild1());
         elt.setChild1(new BigInteger("10"));
         elt.setChild2(BigInteger.ZERO);
         //insert text b/n the 2 elements
-        XmlCursor cur=elt.newCursor();
-       cur.toFirstContentToken();
-        assertTrue(cur.toNextSibling());
-        cur.insertChars("My chars");
-        assertTrue( !doc.validate(validateOptions));
-        showErrors();
-        String[] errExpected = new String[]{
-            XmlErrorCodes.ELEM_COMPLEX_TYPE_LOCALLY_VALID$ELEMENT_ONLY_WITH_TEXT};
-                            assertTrue(compareErrorCodes(errExpected));
+        try (XmlCursor cur = elt.newCursor()) {
+            cur.toFirstContentToken();
+            assertTrue(cur.toNextSibling());
+            cur.insertChars("My chars");
+            assertTrue( !doc.validate(validateOptions));
+            showErrors();
+            String[] errExpected = new String[]{
+                XmlErrorCodes.ELEM_COMPLEX_TYPE_LOCALLY_VALID$ELEMENT_ONLY_WITH_TEXT};
+                                assertTrue(compareErrorCodes(errExpected));
 
-        //should be valid w/o the Text there
-        cur.toPrevToken();
-         assertEquals("<xml-fragment>" +
-                "<child1>10</child1>My chars<child2>0</child2>" +
-                "</xml-fragment>", elt.xmlText());
-       assertTrue(cur.removeXml());
-        try {
+            //should be valid w/o the Text there
+            cur.toPrevToken();
+            assertEquals("<xml-fragment>" +
+                    "<child1>10</child1>My chars<child2>0</child2>" +
+                    "</xml-fragment>", elt.xmlText());
+            assertTrue(cur.removeXml());
             assertTrue( doc.validate(validateOptions));
-        }
-        catch (Throwable t) {
+        } catch (Throwable t) {
             showErrors();
             throw t;
         }

--- a/src/test/java/scomp/namespace/checkin/PreserveNamespaces.java
+++ b/src/test/java/scomp/namespace/checkin/PreserveNamespaces.java
@@ -62,17 +62,17 @@ public class PreserveNamespaces
         assertTrue(XmlComparator.lenientlyCompareTwoXmlStrings(env1.getEnvelope().getBody().xmlText(), env2.getEnvelope().getBody().xmlText(), diag));
 
         // navigate to the dFahrenhiet element and check for the XSD namespace
-        XmlCursor env2Cursor = env2.newCursor();
-        assertTrue(env2Cursor.toFirstChild());      // <Envelope>
-        assertTrue(env2Cursor.toFirstChild());      // <Body>
-        assertTrue(env2Cursor.toFirstChild());      // <ConvertTemperature>
-        if (env2Cursor.toFirstChild())               // <dFahrenheit>
-        {
-            assertEquals("Element name mismatch!", env2Cursor.getName(), new QName("", "dFahrenheit"));
-            assertEquals("Element val mismatch!", "88", env2Cursor.getTextValue());
-            assertEquals("XSD Namespace has been dropped", "http://www.w3.org/2001/XMLSchema", env2Cursor.namespaceForPrefix("xsd"));
+        try (XmlCursor env2Cursor = env2.newCursor()) {
+            assertTrue(env2Cursor.toFirstChild());      // <Envelope>
+            assertTrue(env2Cursor.toFirstChild());      // <Body>
+            assertTrue(env2Cursor.toFirstChild());      // <ConvertTemperature>
+            if (env2Cursor.toFirstChild())               // <dFahrenheit>
+            {
+                assertEquals("Element name mismatch!", env2Cursor.getName(), new QName("", "dFahrenheit"));
+                assertEquals("Element val mismatch!", "88", env2Cursor.getTextValue());
+                assertEquals("XSD Namespace has been dropped", "http://www.w3.org/2001/XMLSchema", env2Cursor.namespaceForPrefix("xsd"));
+            }
         }
-
     }
 
     @Test
@@ -96,15 +96,15 @@ public class PreserveNamespaces
         assertTrue("new envelope has missing XSD namespace declaration", XmlComparator.lenientlyCompareTwoXmlStrings(env1.getEnvelope().getBody().xmlText(), env2.getEnvelope().getBody().xmlText(), diag));
 
         // navigate to the 'element' element and check for the XSD namespace
-        XmlCursor env2Cursor = env2.newCursor();
-        assertTrue(env2Cursor.toFirstChild());      // <Envelope>
-        assertTrue(env2Cursor.toFirstChild());      // <Body>
-        if (env2Cursor.toFirstChild())              // <element>
-        {
-            assertEquals("Element name mismatch!", env2Cursor.getName(), new QName("http://www.w3.org/2001/XMLSchema", "element"));
-            assertEquals("XSD Namespace has been dropped", "http://www.w3.org/2001/XMLSchema", env2Cursor.namespaceForPrefix("xsd"));
+        try (XmlCursor env2Cursor = env2.newCursor()) {
+            assertTrue(env2Cursor.toFirstChild());      // <Envelope>
+            assertTrue(env2Cursor.toFirstChild());      // <Body>
+            if (env2Cursor.toFirstChild())              // <element>
+            {
+                assertEquals("Element name mismatch!", env2Cursor.getName(), new QName("http://www.w3.org/2001/XMLSchema", "element"));
+                assertEquals("XSD Namespace has been dropped", "http://www.w3.org/2001/XMLSchema", env2Cursor.namespaceForPrefix("xsd"));
+            }
         }
-
     }
 
     @Test
@@ -128,16 +128,16 @@ public class PreserveNamespaces
         assertTrue("new envelope has missing XSD namespace declaration", XmlComparator.lenientlyCompareTwoXmlStrings(env1.getEnvelope().getBody().xmlText(), env2.getEnvelope().getBody().xmlText(), diag));
 
         // navigate to the soap element and check for the 'soap' namespace
-        XmlCursor env2Cursor = env2.newCursor();
-        assertTrue(env2Cursor.toFirstChild());      // <Envelope>
-        assertTrue(env2Cursor.toFirstChild());      // <Body>
-        assertTrue(env2Cursor.toFirstChild());      // <Fault>
-        if (env2Cursor.toFirstChild())              // <faultcode>
-        {
-            assertEquals("Element name mismatch!", env2Cursor.getName(), new QName("", "faultcode"));
-            assertEquals("soap Namespace has been dropped", "http://schemas.xmlsoap.org/soap/envelope/", env2Cursor.namespaceForPrefix("soap"));
+        try (XmlCursor env2Cursor = env2.newCursor()) {
+            assertTrue(env2Cursor.toFirstChild());      // <Envelope>
+            assertTrue(env2Cursor.toFirstChild());      // <Body>
+            assertTrue(env2Cursor.toFirstChild());      // <Fault>
+            if (env2Cursor.toFirstChild())              // <faultcode>
+            {
+                assertEquals("Element name mismatch!", env2Cursor.getName(), new QName("", "faultcode"));
+                assertEquals("soap Namespace has been dropped", "http://schemas.xmlsoap.org/soap/envelope/", env2Cursor.namespaceForPrefix("soap"));
+            }
         }
-
     }
 
 }

--- a/src/test/java/scomp/substGroup/detailed/UserReportedTest.java
+++ b/src/test/java/scomp/substGroup/detailed/UserReportedTest.java
@@ -15,6 +15,7 @@
 
 package scomp.substGroup.detailed;
 
+import org.apache.xmlbeans.XmlCursor;
 import org.junit.Test;
 import scomp.common.BaseCase;
 import xbean.scomp.substGroup.userReported.ADocument;
@@ -62,8 +63,12 @@ public class UserReportedTest extends BaseCase{
         RootDocument.Root m = mdoc.addNewRoot();
         m.setAArray(arr);
         T[] arr1=m.getAArray();
-        arr1[2].newCursor().setName(new QName("http://xbean/scomp/substGroup/UserReported","b"));
-        arr1[4].newCursor().setName(new QName("http://xbean/scomp/substGroup/UserReported","b"));
+        try (XmlCursor c = arr1[2].newCursor()) {
+            c.setName(new QName("http://xbean/scomp/substGroup/UserReported","b"));
+        }
+        try (XmlCursor c = arr1[4].newCursor()) {
+            c.setName(new QName("http://xbean/scomp/substGroup/UserReported","b"));
+        }
 
        /* if (! mdoc.toString().equals(input))
            throw new Exception(mdoc.toString());

--- a/src/test/java/scomp/substGroup/restriction/detailed/Block.java
+++ b/src/test/java/scomp/substGroup/restriction/detailed/Block.java
@@ -85,13 +85,14 @@ public class Block extends BaseCase {
             bs
         });
 
-         XmlCursor cur=doc.newCursor();
-        cur.toFirstContentToken();
-        cur.toNextToken();
-          cur.toNextToken();
-          cur.toNextToken();
-        assertEquals(XmlCursor.TokenType.START,cur.currentTokenType());
-        cur.setName(new QName("http://xbean/scomp/substGroup/Block","businessShirt","pre"));
+        try (XmlCursor cur = doc.newCursor()) {
+            cur.toFirstContentToken();
+            cur.toNextToken();
+            cur.toNextToken();
+            cur.toNextToken();
+            assertEquals(XmlCursor.TokenType.START,cur.currentTokenType());
+            cur.setName(new QName("http://xbean/scomp/substGroup/Block","businessShirt","pre"));
+        }
         System.out.println("*************** "+doc.xmlText());
 
         try {

--- a/src/test/java/tools/xml/XmlComparator.java
+++ b/src/test/java/tools/xml/XmlComparator.java
@@ -125,13 +125,13 @@ public class XmlComparator
         XmlObject xobj1 = XmlObject.Factory.parse(actual);
         XmlObject xobj2 = XmlObject.Factory.parse(expect);
 
-        XmlCursor cur1 = xobj1.newCursor();
-        XmlCursor cur2 = xobj2.newCursor();
+        try (XmlCursor cur1 = xobj1.newCursor();
+            XmlCursor cur2 = xobj2.newCursor()) {
+            cur1.toFirstChild();
+            cur2.toFirstChild();
 
-        cur1.toFirstChild();
-        cur2.toFirstChild();
-
-        return lenientlyCompareTwoXmlStrings(cur1,  cur2, diag);
+            return lenientlyCompareTwoXmlStrings(cur1,  cur2, diag);
+        }
     }
 
     /**

--- a/src/test/java/xmlcursor/checkin/AddToSelectionTest.java
+++ b/src/test/java/xmlcursor/checkin/AddToSelectionTest.java
@@ -58,17 +58,17 @@ public class AddToSelectionTest extends BasicCursorTestCase {
         assertEquals(4, m_xc.getSelectionCount());
 
         //check results
-        XmlCursor m_xc1 = XmlObject.Factory.parse(sXml).newCursor();
-        m_xc.toSelection(0); //reset cursor
-        int i = m_xc.getSelectionCount();
-        while ((tok = m_xc1.toNextToken()) != XmlCursor.TokenType.NONE) {
-            //assertEquals(true,m_xc.hasNextSelection());
-            assertEquals(m_xc.toNextToken(), tok);
-            m_xc.toNextSelection();
+        try (XmlCursor m_xc1 = XmlObject.Factory.parse(sXml).newCursor()) {
+            m_xc.toSelection(0); //reset cursor
+            int i = m_xc.getSelectionCount();
+            while ((tok = m_xc1.toNextToken()) != XmlCursor.TokenType.NONE) {
+                //assertEquals(true,m_xc.hasNextSelection());
+                assertEquals(m_xc.toNextToken(), tok);
+                m_xc.toNextSelection();
+            }
+            //second cursor should be at the end of selections too...
+            assertFalse(m_xc.toNextSelection());
         }
-        //second cursor should be at the end of selections too...
-        assertFalse(m_xc.toNextSelection());
-        m_xc1.dispose();
     }
 
     @Test
@@ -85,8 +85,8 @@ public class AddToSelectionTest extends BasicCursorTestCase {
     }
 
     @Test(expected = Throwable.class)
-    public void testAddAfterDispose() {
-        m_xc.dispose();
+    public void testAddAfterClose() {
+        m_xc.close();
         m_xc.addToSelection();
 
     }

--- a/src/test/java/xmlcursor/checkin/AnnotationsTests.java
+++ b/src/test/java/xmlcursor/checkin/AnnotationsTests.java
@@ -32,31 +32,31 @@ public class AnnotationsTests {
     //
     @Test
     public void testBasicXml() throws Exception {
-        XmlCursor c = XmlObject.Factory.parse(Common.XML_ATTR_TEXT, null).newCursor();
+        try (XmlCursor c = XmlObject.Factory.parse(Common.XML_ATTR_TEXT, null).newCursor()) {
+            TestBookmark a1 = new TestBookmark();
 
-        TestBookmark a1 = new TestBookmark();
+            c.setBookmark(a1);
 
-        c.setBookmark(a1);
+            TestBookmark a2 = new TestBookmark();
 
-        TestBookmark a2 = new TestBookmark();
+            c.toNextToken();
+            c.toNextToken();
 
-        c.toNextToken();
-        c.toNextToken();
+            c.setBookmark(a2);
 
-        c.setBookmark(a2);
+            c.toPrevToken();
+            c.toPrevToken();
 
-        c.toPrevToken();
-        c.toPrevToken();
+            assertEquals(c.getBookmark(TestBookmark.class), a1);
 
-        assertEquals(c.getBookmark(TestBookmark.class), a1);
+            c.toNextToken();
+            c.toNextToken();
 
-        c.toNextToken();
-        c.toNextToken();
+            assertEquals(c.getBookmark(TestBookmark.class), a2);
 
-        assertEquals(c.getBookmark(TestBookmark.class), a2);
+            c.toNextToken();
 
-        c.toNextToken();
-
-        assertNull(c.getBookmark(TestBookmark.class));
+            assertNull(c.getBookmark(TestBookmark.class));
+        }
     }
 }

--- a/src/test/java/xmlcursor/checkin/CloseTest.java
+++ b/src/test/java/xmlcursor/checkin/CloseTest.java
@@ -22,14 +22,14 @@ import xmlcursor.common.BasicCursorTestCase;
 import xmlcursor.common.Common;
 
 
-public class DisposeTest extends BasicCursorTestCase {
+public class CloseTest extends BasicCursorTestCase {
 
     @Test
-    public void testMultipleDispose() throws Exception {
+    public void testMultipleClose() throws Exception {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO);
         m_xc = m_xo.newCursor();
-        m_xc.dispose();
-        m_xc.dispose();
+        m_xc.close();
+        m_xc.close();
     }
 }
 

--- a/src/test/java/xmlcursor/checkin/ComparePositionTest.java
+++ b/src/test/java/xmlcursor/checkin/ComparePositionTest.java
@@ -38,13 +38,10 @@ public class ComparePositionTest extends BasicCursorTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void testComparePositionDifferentDocs() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        m_xc.toFirstChild();
-        xc0.toFirstChild();
-        try {
+        try (XmlCursor xc0 = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor()) {
+            m_xc.toFirstChild();
+            xc0.toFirstChild();
             m_xc.comparePosition(xc0);
-        } finally {
-            xc0.dispose();
         }
     }
 
@@ -58,42 +55,33 @@ public class ComparePositionTest extends BasicCursorTestCase {
     @Test
     public void testComparePositionRightInTEXT() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
             toNextTokenOfType(m_xc, TokenType.TEXT);
             toNextTokenOfType(xc0, TokenType.TEXT);
             xc0.toNextChar(1);
             assertEquals(-1, m_xc.comparePosition(xc0));
-        } finally {
-            xc0.dispose();
         }
     }
 
     @Test
     public void testComparePositionLeftInTEXT() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
             toNextTokenOfType(m_xc, TokenType.TEXT);
             toNextTokenOfType(xc0, TokenType.TEXT);
             m_xc.toNextChar(1);
             assertEquals(1, m_xc.comparePosition(xc0));
-        } finally {
-            xc0.dispose();
         }
     }
 
     @Test
     public void testComparePositionENDandENDDOC() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
             m_xc.toEndDoc();
             xc0.toEndDoc();
             xc0.toPrevToken();
             assertEquals(1, m_xc.comparePosition(xc0));
-        } finally {
-            xc0.dispose();
         }
     }
 }

--- a/src/test/java/xmlcursor/checkin/CopyTest.java
+++ b/src/test/java/xmlcursor/checkin/CopyTest.java
@@ -185,26 +185,27 @@ public class CopyTest extends BasicCursorTestCase {
         m_xo = XmlObject.Factory.parse(
                 JarUtil.getResourceFromJar(Common.TRANXML_FILE_XMLCURSOR_PO));
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        m_xc.selectPath(ns+" .//po:shipTo/po:city");
-        m_xc.toNextSelection();
-        xc1.selectPath(ns+" .//po:billTo/po:city");
-        xc1.toNextSelection();
-        xc1.toNextToken();
-        xc1.toNextChar(4);  // should be at 'T' in "Old Town"
-        m_xc.copyXml(xc1);     // should be "Old <city>Mill Valley</city>Town"
-        // verify xc1
-        xc1.toPrevToken();
-        assertEquals(TokenType.END, xc1.currentTokenType());
-        xc1.toPrevToken();
-        assertEquals("Mill Valley", xc1.getChars());
-        xc1.toPrevToken();
-        assertEquals(TokenType.START, xc1.currentTokenType());
-        assertEquals(new QName("city").getLocalPart(),
-                xc1.getName().getLocalPart());
-        xc1.toPrevToken();
-        assertEquals("Old ", xc1.getChars());
-        // verify m_xc
-        assertEquals("<po:city "+exp_ns+">Mill Valley</po:city>", m_xc.xmlText());
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            m_xc.selectPath(ns+" .//po:shipTo/po:city");
+            m_xc.toNextSelection();
+            xc1.selectPath(ns+" .//po:billTo/po:city");
+            xc1.toNextSelection();
+            xc1.toNextToken();
+            xc1.toNextChar(4);  // should be at 'T' in "Old Town"
+            m_xc.copyXml(xc1);     // should be "Old <city>Mill Valley</city>Town"
+            // verify xc1
+            xc1.toPrevToken();
+            assertEquals(TokenType.END, xc1.currentTokenType());
+            xc1.toPrevToken();
+            assertEquals("Mill Valley", xc1.getChars());
+            xc1.toPrevToken();
+            assertEquals(TokenType.START, xc1.currentTokenType());
+            assertEquals(new QName("city").getLocalPart(),
+                    xc1.getName().getLocalPart());
+            xc1.toPrevToken();
+            assertEquals("Old ", xc1.getChars());
+            // verify m_xc
+            assertEquals("<po:city "+exp_ns+">Mill Valley</po:city>", m_xc.xmlText());
+        }
     }
 }

--- a/src/test/java/xmlcursor/checkin/CopyXmlContentsTest.java
+++ b/src/test/java/xmlcursor/checkin/CopyXmlContentsTest.java
@@ -73,11 +73,12 @@ public class CopyXmlContentsTest extends BasicCursorTestCase {
 		String sDoc1 = Common.XML_FOO_DIGITS;
 		String sDoc2 = Common.XML_FOO_2ATTR_TEXT;
 		m_xc = XmlObject.Factory.parse(sDoc1).newCursor();
-		XmlCursor xc1 = XmlObject.Factory.parse(sDoc2).newCursor();
-		toNextTokenOfType(m_xc, TokenType.TEXT);
-		toNextTokenOfType(xc1, TokenType.START);
-		boolean result = m_xc.copyXmlContents(xc1);
-		assertFalse(result);
+		try (XmlCursor xc1 = XmlObject.Factory.parse(sDoc2).newCursor()) {
+    		toNextTokenOfType(m_xc, TokenType.TEXT);
+    		toNextTokenOfType(xc1, TokenType.START);
+    		boolean result = m_xc.copyXmlContents(xc1);
+    		assertFalse(result);
+		}
 	}
 
 	@Test
@@ -117,37 +118,42 @@ public class CopyXmlContentsTest extends BasicCursorTestCase {
 	public void testCopyWholeDoc() throws Exception {
 		String sDoc1 = Common.XML_FOO_BAR_WS_TEXT;
 		String sDoc2 = "<root></root>";
-		m_xc = XmlObject.Factory.parse(sDoc1).newCursor();
-		XmlCursor xc1 = XmlObject.Factory.parse(sDoc2).newCursor();
-		xc1.toFirstChild();
-		String sExpectedXml = m_xc.xmlText();
-		boolean result = m_xc.copyXmlContents(xc1);
-		toPrevTokenOfType(xc1, TokenType.STARTDOC);
-		toNextTokenOfType(xc1, TokenType.START);
-		assertEquals(sExpectedXml, xc1.xmlText());
+
+		try (XmlCursor xc1 = XmlObject.Factory.parse(sDoc1).newCursor();
+		    XmlCursor xc2 = XmlObject.Factory.parse(sDoc2).newCursor()) {
+    		xc2.toFirstChild();
+    		String sExpectedXml = xc1.xmlText();
+    		boolean result = xc1.copyXmlContents(xc2);
+    		toPrevTokenOfType(xc2, TokenType.STARTDOC);
+    		toNextTokenOfType(xc2, TokenType.START);
+    		assertEquals(sExpectedXml, xc2.xmlText());
+		}
 
 		//namespaces are not copied
 		sDoc1 = Common.XML_FOO_NS_PREFIX;
 		sDoc2 = "<root></root>";
-		m_xc = XmlObject.Factory.parse(sDoc1).newCursor();
-		xc1 = XmlObject.Factory.parse(sDoc2).newCursor();
-		sExpectedXml = m_xc.xmlText();
-		xc1.toFirstChild();
+		try (XmlCursor xc1 = XmlObject.Factory.parse(sDoc1).newCursor();
+		    XmlCursor xc2 = XmlObject.Factory.parse(sDoc2).newCursor()) {
+		    String sExpectedXml = xc1.xmlText();
+    		xc2.toFirstChild();
 
-		result = m_xc.copyXmlContents(xc1);
-		toPrevTokenOfType(xc1, TokenType.STARTDOC);
-		assertNotEquals(sExpectedXml, xc1.xmlText());
+    		boolean result = xc1.copyXmlContents(xc2);
+    		toPrevTokenOfType(xc2, TokenType.STARTDOC);
+    		assertNotEquals(sExpectedXml, xc2.xmlText());
 
-		//attributes are not copied
-		sDoc1 = Common.XML_FOO_2ATTR;
-		sDoc2 = "<root></root>";
-		m_xc = XmlObject.Factory.parse(sDoc1).newCursor();
-		xc1 = XmlObject.Factory.parse(sDoc2).newCursor();
-		sExpectedXml = m_xc.xmlText();
-		xc1.toFirstChild();
+    		//attributes are not copied
+    		sDoc1 = Common.XML_FOO_2ATTR;
+    		sDoc2 = "<root></root>";
+		}
 
-		result = m_xc.copyXmlContents(xc1);
-		toPrevTokenOfType(xc1, TokenType.STARTDOC);
-		assertNotEquals(sExpectedXml, xc1.xmlText());
+		try (XmlCursor xc1 = XmlObject.Factory.parse(sDoc1).newCursor();
+    	    XmlCursor xc2 = XmlObject.Factory.parse(sDoc2).newCursor()) {
+    	    String sExpectedXml = xc1.xmlText();
+    		xc2.toFirstChild();
+
+    		boolean result = xc1.copyXmlContents(xc2);
+    		toPrevTokenOfType(xc2, TokenType.STARTDOC);
+    		assertNotEquals(sExpectedXml, xc2.xmlText());
+		}
 	}
 }

--- a/src/test/java/xmlcursor/checkin/CopyXmlContentsTest.java
+++ b/src/test/java/xmlcursor/checkin/CopyXmlContentsTest.java
@@ -44,7 +44,7 @@ public class CopyXmlContentsTest extends BasicCursorTestCase {
 		XmlCursor xc1 = XmlObject.Factory.parse(sDoc2).newCursor();
 		toNextTokenOfType(m_xc, TokenType.START);
 		toNextTokenOfType(xc1, TokenType.START);
-		xc1.dispose();
+		xc1.close();
 		m_xc.copyXmlContents(xc1);
 	}
 
@@ -53,14 +53,14 @@ public class CopyXmlContentsTest extends BasicCursorTestCase {
 		String sDoc1 = Common.XML_FOO_DIGITS;
 		String sDoc2 = Common.XML_FOO_2ATTR_TEXT;
 		m_xc = XmlObject.Factory.parse(sDoc1).newCursor();
-		XmlCursor xc1 = XmlObject.Factory.parse(sDoc2).newCursor();
-		toNextTokenOfType(m_xc, TokenType.START);
-		toNextTokenOfType(xc1, TokenType.TEXT);
-		m_xc.copyXmlContents(xc1);
-		xc1.toParent();
-		// verify xc1
-		assertEquals("01234text", xc1.getTextValue());
-		xc1.dispose();
+		try (XmlCursor xc1 = XmlObject.Factory.parse(sDoc2).newCursor()) {
+    		toNextTokenOfType(m_xc, TokenType.START);
+    		toNextTokenOfType(xc1, TokenType.TEXT);
+    		m_xc.copyXmlContents(xc1);
+    		xc1.toParent();
+    		// verify xc1
+    		assertEquals("01234text", xc1.getTextValue());
+		}
 
 		// verify m_xc
 		toNextTokenOfType(m_xc, TokenType.TEXT); //get to the text

--- a/src/test/java/xmlcursor/checkin/IsAtSamePositionAsTest.java
+++ b/src/test/java/xmlcursor/checkin/IsAtSamePositionAsTest.java
@@ -32,27 +32,30 @@ public class IsAtSamePositionAsTest extends BasicCursorTestCase{
 
 	@Test
 	public void testNormalCase() {
-		XmlCursor m_xc1 = m_xo.newCursor();
-		m_xc.toFirstChild();
-		m_xc1.toFirstChild();
-		assertTrue(m_xc.isAtSamePositionAs(m_xc1));
+	    try (XmlCursor m_xc1 = m_xo.newCursor()) {
+    		m_xc.toFirstChild();
+    		m_xc1.toFirstChild();
+    		assertTrue(m_xc.isAtSamePositionAs(m_xc1));
+	    }
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testSamePosDiffDoc() throws Exception {
-		XmlCursor m_xc1 = XmlObject.Factory.parse(sDoc).newCursor();
-		m_xc.toFirstChild();
-		m_xc1.toFirstChild();
-		m_xc.isAtSamePositionAs(m_xc1);
+	    try (XmlCursor m_xc1 = XmlObject.Factory.parse(sDoc).newCursor()) {
+    		m_xc.toFirstChild();
+    		m_xc1.toFirstChild();
+    		m_xc.isAtSamePositionAs(m_xc1);
+	    }
 	}
 
 	@Test
 	public void testDiffPosSameDoc() throws Exception {
-		XmlCursor m_xc1 = m_xo.newCursor();
-		m_xc.toFirstChild();
-		m_xc1.toFirstChild();
-		m_xc1.toFirstAttribute();
-		assertFalse(m_xc.isAtSamePositionAs(m_xc1));
+	    try (XmlCursor m_xc1 = m_xo.newCursor()) {
+    		m_xc.toFirstChild();
+    		m_xc1.toFirstChild();
+    		m_xc1.toFirstAttribute();
+    		assertFalse(m_xc.isAtSamePositionAs(m_xc1));
+	    }
 	}
 
 	@Test(expected = Exception.class)

--- a/src/test/java/xmlcursor/checkin/IsInSameDocumentTest.java
+++ b/src/test/java/xmlcursor/checkin/IsInSameDocumentTest.java
@@ -31,27 +31,21 @@ public class IsInSameDocumentTest extends BasicCursorTestCase {
     @Test
     public void testSameDocSTARTDOCandENDDOC() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        xc0.toEndDoc();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            xc0.toEndDoc();
             assertTrue(m_xc.isInSameDocument(xc0));
             assertTrue(xc0.isInSameDocument(m_xc));
-        } finally {
-            xc0.dispose();
         }
     }
 
     @Test
     public void testSameDocNAMESPACEandATTR() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_DIGITS).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
             toNextTokenOfType(m_xc, TokenType.NAMESPACE);
             toNextTokenOfType(xc0, TokenType.ATTR);
             assertTrue(m_xc.isInSameDocument(xc0));
             assertTrue(xc0.isInSameDocument(m_xc));
-        } finally {
-            xc0.dispose();
         }
     }
 
@@ -64,29 +58,25 @@ public class IsInSameDocumentTest extends BasicCursorTestCase {
     @Test
     public void testSameDocDifferentDocs() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        toNextTokenOfType(xc0, TokenType.TEXT);
-        try {
+        try (XmlCursor xc0 = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.TEXT);
+            toNextTokenOfType(xc0, TokenType.TEXT);
+
             assertFalse(m_xc.isInSameDocument(xc0));
             assertFalse(xc0.isInSameDocument(m_xc));
-        } finally {
-            xc0.dispose();
         }
     }
 
     @Test
     public void testSameDocTEXTpositional() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        toNextTokenOfType(xc0, TokenType.TEXT);
-        xc0.toNextChar(2);
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.TEXT);
+            toNextTokenOfType(xc0, TokenType.TEXT);
+            xc0.toNextChar(2);
+
             assertTrue(m_xc.isInSameDocument(xc0));
             assertTrue(xc0.isInSameDocument(m_xc));
-        } finally {
-            xc0.dispose();
         }
     }
 }

--- a/src/test/java/xmlcursor/checkin/MoveCharsTest.java
+++ b/src/test/java/xmlcursor/checkin/MoveCharsTest.java
@@ -32,17 +32,14 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsOverlap() throws Exception {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_DIGITS);
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.TEXT);
-        toNextTokenOfType(xc1, TokenType.TEXT);
-        xc1.toNextChar(2);
-        try {
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            toNextTokenOfType(xc1, TokenType.TEXT);
+            xc1.toNextChar(2);
             assertEquals("234", xc1.getChars());
             assertEquals(3, m_xc.moveChars(3, xc1));
             assertEquals("34", m_xc.getChars());
             assertEquals("34", xc1.getChars());
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -50,23 +47,20 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsNoOverlap() throws Exception {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_DIGITS);
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        XmlCursor xc2 = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.TEXT);
-        xc1.toCursor(m_xc);
-        xc2.toCursor(m_xc);
-        xc1.toNextChar(3);
-        xc2.toNextChar(4);
-        try {
+        try (XmlCursor xc1 = m_xo.newCursor();
+            XmlCursor xc2 = m_xo.newCursor()) {
+            xc1.toCursor(m_xc);
+            xc2.toCursor(m_xc);
+            xc1.toNextChar(3);
+            xc2.toNextChar(4);
+
             assertEquals("34", xc1.getChars());
             assertEquals("4", xc2.getChars());
             assertEquals(2, m_xc.moveChars(2, xc1));
             assertEquals("20134", m_xc.getChars());
             assertEquals("34", xc1.getChars());
             assertEquals("4", xc2.getChars());
-        } finally {
-            xc1.dispose();
-            xc2.dispose();
         }
     }
 
@@ -82,11 +76,8 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsSibling() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT);
+            XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
             assertFalse(xc0.isAtSamePositionAs(xc1));
             assertEquals(4, xc1.moveChars(4, xc0));
             assertEquals("0123", xc0.getChars());
@@ -96,9 +87,6 @@ public class MoveCharsTest extends BasicCursorTestCase {
             assertEquals(TokenType.END, xc1.currentTokenType());
 
             xc1.getTextValue();
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -106,11 +94,8 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsNegative() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT);
+            XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
             assertFalse(xc0.isAtSamePositionAs(xc1));
             assertEquals(4, xc1.moveChars(-1, xc0));
             assertEquals("0123", xc0.getChars());
@@ -118,9 +103,6 @@ public class MoveCharsTest extends BasicCursorTestCase {
             assertEquals("WXYZ0123", xc0.getTextValue());
             assertEquals(TokenType.END, xc1.currentTokenType());
             xc1.getTextValue();
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -128,11 +110,8 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsZero() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT);
+            XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
             assertFalse(xc0.isAtSamePositionAs(xc1));
             assertEquals(0, xc1.moveChars(0, xc0));
             assertEquals("0123", xc0.getChars());
@@ -140,9 +119,6 @@ public class MoveCharsTest extends BasicCursorTestCase {
             assertEquals("0123", xc0.getTextValue());
             assertEquals(TokenType.TEXT, xc1.currentTokenType());
             assertEquals("WXYZ", xc1.getChars());
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -150,12 +126,9 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsToSTARTDOC() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        XmlCursor xc0 = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.TEXT);
-        try{
+        try (XmlCursor xc0 = m_xo.newCursor()) {
             m_xc.moveChars(4, xc0);
-        } finally {
-            xc0.dispose();
         }
     }
 
@@ -163,16 +136,14 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsToPROCINST() throws Exception {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_PROCINST);
         m_xc = m_xo.newCursor();
-        XmlCursor xc0 = m_xo.newCursor();
-        toNextTokenOfType(xc0, TokenType.PROCINST);
         toNextTokenOfType(m_xc, TokenType.TEXT);
-        m_xc.moveChars(1, xc0);
-        xc0.toPrevToken();
-        try {
+        try (XmlCursor xc0 = m_xo.newCursor()) {
+            toNextTokenOfType(xc0, TokenType.PROCINST);
+            m_xc.moveChars(1, xc0);
+            xc0.toPrevToken();
+
             assertEquals("t", xc0.getChars());
             assertEquals("ext", m_xc.getChars());
-        } finally {
-            xc0.dispose();
         }
     }
 
@@ -180,11 +151,8 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsGTmax() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT);
+            XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
             assertFalse(xc0.isAtSamePositionAs(xc1));
             assertEquals(4, xc1.moveChars(1000, xc0));
             assertEquals("0123", xc0.getChars());
@@ -194,9 +162,6 @@ public class MoveCharsTest extends BasicCursorTestCase {
             assertEquals(TokenType.END, xc1.currentTokenType());
 
             xc1.getTextValue();
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -204,15 +169,15 @@ public class MoveCharsTest extends BasicCursorTestCase {
     public void testMoveCharsToNewDocument() throws Exception {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_DIGITS);
         m_xc = m_xo.newCursor();
-        XmlObject xo = XmlObject.Factory.parse(Common.XML_FOO_2ATTR_TEXT);
-        XmlCursor xc1 = xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.TEXT);
-        toNextTokenOfType(xc1, TokenType.TEXT);
-        assertEquals(5, m_xc.moveChars(5, xc1));
-        xc1.toParent();
-        // verify xc1
-        assertEquals("01234text", xc1.getTextValue());
-        xc1.dispose();
+        XmlObject xo = XmlObject.Factory.parse(Common.XML_FOO_2ATTR_TEXT);
+        try (XmlCursor xc1 = xo.newCursor()) {
+            toNextTokenOfType(xc1, TokenType.TEXT);
+            assertEquals(5, m_xc.moveChars(5, xc1));
+            xc1.toParent();
+            // verify xc1
+            assertEquals("01234text", xc1.getTextValue());
+        }
         // verify m_xc
         assertEquals(TokenType.END, m_xc.currentTokenType());
     }

--- a/src/test/java/xmlcursor/checkin/MoveTest.java
+++ b/src/test/java/xmlcursor/checkin/MoveTest.java
@@ -44,14 +44,14 @@ public class MoveTest extends BasicCursorTestCase {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_DIGITS);
         m_xc = m_xo.newCursor();
         XmlObject xo = XmlObject.Factory.parse(Common.XML_FOO_2ATTR_TEXT);
-        XmlCursor xc1 = xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        toNextTokenOfType(xc1, TokenType.TEXT);
-        m_xc.moveXml(xc1);
-        xc1.toParent();
-        // verify xc1
-        assertEquals("01234text", xc1.getTextValue());
-        xc1.dispose();
+        try (XmlCursor xc1 = xo.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.TEXT);
+            toNextTokenOfType(xc1, TokenType.TEXT);
+            m_xc.moveXml(xc1);
+            xc1.toParent();
+            // verify xc1
+            assertEquals("01234text", xc1.getTextValue());
+        }
         // verify m_xc
         assertEquals(TokenType.END, m_xc.currentTokenType());
     }
@@ -64,48 +64,44 @@ public class MoveTest extends BasicCursorTestCase {
         XmlObject xobj1 = XmlObject.Factory.parse(
                 JarUtil.getResourceFromJar(Common.TRANXML_FILE_XMLCURSOR_PO));
 
-        XmlCursor xc0 = xobj0.newCursor();
-        XmlCursor xc1 = xobj1.newCursor();
+        try (XmlCursor xc0 = xobj0.newCursor();
+            XmlCursor xc1 = xobj1.newCursor()) {
+            xc0.selectPath(Common.CLM_NS_XQUERY_DEFAULT + ".//Initial");
+            xc0.toNextSelection();
 
-        xc0.selectPath(Common.CLM_NS_XQUERY_DEFAULT + ".//Initial");
-        xc0.toNextSelection();
-
-        String sQuery=
-                "declare namespace po=\"http://xbean.test/xmlcursor/PurchaseOrder\"; "+
-                ".//po:zip";
-        xc1.selectPath( sQuery );
-        assertTrue( 0 < xc1.getSelectionCount());
-        xc1.toNextSelection();
-
-
-        xc0.moveXml(xc1); // should move the <Initial>GATX</Initial> element plus the namespace
+            String sQuery=
+                    "declare namespace po=\"http://xbean.test/xmlcursor/PurchaseOrder\"; "+
+                    ".//po:zip";
+            xc1.selectPath( sQuery );
+            assertTrue( 0 < xc1.getSelectionCount());
+            xc1.toNextSelection();
 
 
-        xc1.toPrevSibling();
-        // verify xc1
-        String sExpected = "<ver:Initial " +
-                "xmlns:po=\"http://xbean.test/xmlcursor/PurchaseOrder\" " +
-                "xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\">" +
-                "GATX</ver:Initial>";
-        assertEquals(sExpected, xc1.xmlText());
-        // verify xc0
-        xc0.toNextToken();  // skip the whitespace token
-        assertEquals("123456", xc0.getTextValue());
+            xc0.moveXml(xc1); // should move the <Initial>GATX</Initial> element plus the namespace
 
-        xc0.dispose();
-        xc1.dispose();
 
+            xc1.toPrevSibling();
+            // verify xc1
+            String sExpected = "<ver:Initial " +
+                    "xmlns:po=\"http://xbean.test/xmlcursor/PurchaseOrder\" " +
+                    "xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\">" +
+                    "GATX</ver:Initial>";
+            assertEquals(sExpected, xc1.xmlText());
+            // verify xc0
+            xc0.toNextToken();  // skip the whitespace token
+            assertEquals("123456", xc0.getTextValue());
+        }
     }
 
     @Test
     public void testMoveSameLocation() throws Exception {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_DIGITS);
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        toNextTokenOfType(xc1, TokenType.TEXT);
-        m_xc.moveXml(xc1);
-        xc1.dispose();
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.TEXT);
+            toNextTokenOfType(xc1, TokenType.TEXT);
+            m_xc.moveXml(xc1);
+        }
         assertEquals("01234", m_xc.getChars());
     }
 

--- a/src/test/java/xmlcursor/checkin/MoveTest.java
+++ b/src/test/java/xmlcursor/checkin/MoveTest.java
@@ -112,17 +112,18 @@ public class MoveTest extends BasicCursorTestCase {
         String ns="declare namespace po=\"http://xbean.test/xmlcursor/PurchaseOrder\"; ";
 
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        m_xc.selectPath(ns+" .//po:shipTo/po:city");
-        m_xc.toNextSelection();
-        xc1.selectPath(ns +" .//po:billTo/po:city");
-        xc1.toNextSelection();
-        m_xc.moveXml(xc1);
-        xc1.toPrevToken();
-        xc1.toPrevToken();
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            m_xc.selectPath(ns+" .//po:shipTo/po:city");
+            m_xc.toNextSelection();
+            xc1.selectPath(ns +" .//po:billTo/po:city");
+            xc1.toNextSelection();
+            m_xc.moveXml(xc1);
+            xc1.toPrevToken();
+            xc1.toPrevToken();
 
-        // verify xc1
-        assertEquals("Mill Valley", xc1.getChars());
+            // verify xc1
+            assertEquals("Mill Valley", xc1.getChars());
+        }
 
         // verify m_xc
         m_xc.toNextToken(); // skip the whitespace token
@@ -137,26 +138,27 @@ public class MoveTest extends BasicCursorTestCase {
         String ns="declare namespace po=\"http://xbean.test/xmlcursor/PurchaseOrder\"; ";
 
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        m_xc.selectPath(ns+" .//po:shipTo/po:city");
-        m_xc.toNextSelection();
-        xc1.selectPath(ns+" .//po:billTo/po:city");
-        xc1.toNextSelection();
-        xc1.toNextToken();
-        xc1.toNextChar(4);  // should be at 'T' in "Old Town"
-        m_xc.moveXml(xc1);     // should be "Old <city>Mill Valley</city>Town"
-        // verify xc1
-        xc1.toPrevToken();
-        assertEquals(TokenType.END, xc1.currentTokenType());
-        xc1.toPrevToken();
-        assertEquals("Mill Valley", xc1.getChars());
-        xc1.toPrevToken();
-        assertEquals(TokenType.START, xc1.currentTokenType());
-        assertEquals(new QName("city").getLocalPart(),
-                xc1.getName().getLocalPart());
-        xc1.toPrevToken();
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            m_xc.selectPath(ns+" .//po:shipTo/po:city");
+            m_xc.toNextSelection();
+            xc1.selectPath(ns+" .//po:billTo/po:city");
+            xc1.toNextSelection();
+            xc1.toNextToken();
+            xc1.toNextChar(4);  // should be at 'T' in "Old Town"
+            m_xc.moveXml(xc1);     // should be "Old <city>Mill Valley</city>Town"
+            // verify xc1
+            xc1.toPrevToken();
+            assertEquals(TokenType.END, xc1.currentTokenType());
+            xc1.toPrevToken();
+            assertEquals("Mill Valley", xc1.getChars());
+            xc1.toPrevToken();
+            assertEquals(TokenType.START, xc1.currentTokenType());
+            assertEquals(new QName("city").getLocalPart(),
+                    xc1.getName().getLocalPart());
+            xc1.toPrevToken();
 
-        assertEquals("Old ", xc1.getChars());
+            assertEquals("Old ", xc1.getChars());
+        }
         // verify m_xc
         m_xc.toNextToken(); // skip the whitespace token
 

--- a/src/test/java/xmlcursor/checkin/ToCursorTest.java
+++ b/src/test/java/xmlcursor/checkin/ToCursorTest.java
@@ -30,13 +30,11 @@ public class ToCursorTest extends BasicCursorTestCase {
     @Test
     public void testToCursorMoves() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        xc0.toEndDoc();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            xc0.toEndDoc();
+
             assertTrue(m_xc.toCursor(xc0));
             assertTrue(xc0.isAtSamePositionAs(m_xc));
-        } finally {
-            xc0.dispose();
         }
     }
 
@@ -53,15 +51,13 @@ public class ToCursorTest extends BasicCursorTestCase {
     @Test
     public void testToCursorDifferentDocs() throws Exception {
         m_xc = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        XmlCursor xc0 = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        String s = m_xc.xmlText();
-        toNextTokenOfType(xc0, TokenType.TEXT);
-        try {
+        try (XmlCursor xc0 = XmlObject.Factory.parse(Common.XML_FOO_1ATTR_TEXT).newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.TEXT);
+            String s = m_xc.xmlText();
+            toNextTokenOfType(xc0, TokenType.TEXT);
+
             assertFalse(m_xc.toCursor(xc0));
             assertEquals(s, m_xc.xmlText());
-        } finally {
-            xc0.dispose();
         }
     }
 

--- a/src/test/java/xmlcursor/checkin/ToLastChildElementTest.java
+++ b/src/test/java/xmlcursor/checkin/ToLastChildElementTest.java
@@ -48,16 +48,14 @@ public class ToLastChildElementTest extends BasicCursorTestCase {
         m_xc = XmlObject.Factory.parse("<foo>early<bar>text<char>zap</char><dar>yap</dar></bar></foo>").newCursor();
         toNextTokenOfType(m_xc, TokenType.TEXT);
         assertEquals("early", m_xc.getChars());
-        XmlCursor xc0 = m_xc.newCursor();
-        xc0.toNextSibling();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            xc0.toNextSibling();
+
             assertEquals("textzapyap", xc0.getTextValue());
             xc0.toLastChild();
             assertEquals("yap", xc0.getTextValue());
             assertTrue(m_xc.toLastChild());
             assertEquals("yap", m_xc.getTextValue());
-        } finally {
-            xc0.dispose();
         }
     }
 

--- a/src/test/java/xmlcursor/checkin/ToNextBookmarkTest.java
+++ b/src/test/java/xmlcursor/checkin/ToNextBookmarkTest.java
@@ -37,20 +37,19 @@ public class ToNextBookmarkTest extends BasicCursorTestCase {
         m_xc = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.START);
         m_xc.setBookmark(_theBookmark);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.END);
-        m_xc.setBookmark(_theBookmark1);
-        XmlCursor xc1 = m_xc.newCursor();
-        m_xc.toStartDoc();
-        try {
-            assertEquals(_theBookmark, m_xc.toNextBookmark(SimpleBookmark.class));
-            assertTrue(m_xc.isAtSamePositionAs(xc0));
-            assertEquals(_theBookmark1, m_xc.toNextBookmark(SimpleBookmark.class));
-            assertTrue(m_xc.isAtSamePositionAs(xc1));
-            assertNull(m_xc.toNextBookmark(SimpleBookmark.class));
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.END);
+            m_xc.setBookmark(_theBookmark1);
+
+            try (XmlCursor xc1 = m_xc.newCursor()) {
+                m_xc.toStartDoc();
+
+                assertEquals(_theBookmark, m_xc.toNextBookmark(SimpleBookmark.class));
+                assertTrue(m_xc.isAtSamePositionAs(xc0));
+                assertEquals(_theBookmark1, m_xc.toNextBookmark(SimpleBookmark.class));
+                assertTrue(m_xc.isAtSamePositionAs(xc1));
+                assertNull(m_xc.toNextBookmark(SimpleBookmark.class));
+            }
         }
     }
 
@@ -72,20 +71,19 @@ public class ToNextBookmarkTest extends BasicCursorTestCase {
         m_xc = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.START);
         m_xc.setBookmark(_theBookmark);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.END);
-        m_xc.setBookmark(_difBookmark);
-        XmlCursor xc1 = m_xc.newCursor();
-        m_xc.toStartDoc();
-        try {
-            assertEquals(_theBookmark, m_xc.toNextBookmark(SimpleBookmark.class));
-            assertTrue(m_xc.isAtSamePositionAs(xc0));
-            assertNull(m_xc.toNextBookmark(SimpleBookmark.class));
-            assertEquals(_difBookmark, m_xc.toNextBookmark(DifferentBookmark.class));
-            assertTrue(m_xc.isAtSamePositionAs(xc1));
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.END);
+            m_xc.setBookmark(_difBookmark);
+
+            try (XmlCursor xc1 = m_xc.newCursor()) {
+                m_xc.toStartDoc();
+
+                assertEquals(_theBookmark, m_xc.toNextBookmark(SimpleBookmark.class));
+                assertTrue(m_xc.isAtSamePositionAs(xc0));
+                assertNull(m_xc.toNextBookmark(SimpleBookmark.class));
+                assertEquals(_difBookmark, m_xc.toNextBookmark(DifferentBookmark.class));
+                assertTrue(m_xc.isAtSamePositionAs(xc1));
+            }
         }
     }
 
@@ -100,13 +98,11 @@ public class ToNextBookmarkTest extends BasicCursorTestCase {
         m_xc.toPrevChar(2);
         assertEquals(3, m_xc.removeChars(3));  // '2' should be deleted, along w/ bookmark
         assertEquals("34", m_xc.getChars());
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toStartDoc();
-        try {
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toStartDoc();
+
             assertNull(xc1.toNextBookmark(SimpleBookmark.class));
             assertEquals(TokenType.STARTDOC, xc1.currentTokenType());
-        } finally {
-            xc1.dispose();
         }
     }
 

--- a/src/test/java/xmlcursor/checkin/ToNextSelectionTest.java
+++ b/src/test/java/xmlcursor/checkin/ToNextSelectionTest.java
@@ -72,12 +72,9 @@ public class ToNextSelectionTest extends BasicCursorTestCase {
     public void testToNextSelectionOtherCursor() throws Exception {
         String sXml = "<foo><b>0</b><b>1</b><b>2</b><b>3</b><b>4</b><b>5</b><b>6</b></foo>";
         m_xc = XmlObject.Factory.parse(sXml).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
             m_xc.selectPath("$this//b");
             assertFalse(xc0.toNextSelection());
-        } finally {
-            xc0.dispose();
         }
     }
 
@@ -85,8 +82,7 @@ public class ToNextSelectionTest extends BasicCursorTestCase {
     public void testToNextSelectionTwoCursorsDifferentSelections() throws Exception {
         String sXml = "<foo><a>X</a><b>0</b><a>Y</a><b>1</b><a>Z</a><b>2</b></foo>";
         m_xc = XmlObject.Factory.parse(sXml).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
             xc0.selectPath("$this//a");
             xc0.toNextSelection();
             assertEquals(3, xc0.getSelectionCount());
@@ -97,8 +93,6 @@ public class ToNextSelectionTest extends BasicCursorTestCase {
             assertEquals("Y", xc0.getTextValue());
             assertTrue(m_xc.toNextSelection());
             assertEquals("1", m_xc.getTextValue());
-        } finally {
-            xc0.dispose();
         }
     }
 
@@ -106,8 +100,7 @@ public class ToNextSelectionTest extends BasicCursorTestCase {
     public void testToNextSelectionTwoCursorsSameSelections() throws Exception {
         String sXml = "<foo><a>X</a><b>0</b><a>Y</a><b>1</b><a>Z</a><b>2</b></foo>";
         m_xc = XmlObject.Factory.parse(sXml).newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
             xc0.selectPath("$this//b");
             xc0.toNextSelection();
             assertEquals(3, xc0.getSelectionCount());
@@ -124,8 +117,6 @@ public class ToNextSelectionTest extends BasicCursorTestCase {
             assertEquals("2", m_xc.getTextValue());
             assertFalse(xc0.toNextSelection());
             assertFalse(m_xc.toNextSelection());
-        } finally {
-            xc0.dispose();
         }
     }
 }

--- a/src/test/java/xmlcursor/checkin/ToPrevBookmarkTest.java
+++ b/src/test/java/xmlcursor/checkin/ToPrevBookmarkTest.java
@@ -37,20 +37,18 @@ public class ToPrevBookmarkTest extends BasicCursorTestCase {
         m_xc = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.START);
         m_xc.setBookmark(_theBookmark);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.END);
-        m_xc.setBookmark(_theBookmark1);
-        XmlCursor xc1 = m_xc.newCursor();
-        m_xc.toEndDoc();
-        try {
-            assertEquals(_theBookmark1, m_xc.toPrevBookmark(SimpleBookmark.class));
-            assertTrue(m_xc.isAtSamePositionAs(xc1));
-            assertEquals(_theBookmark, m_xc.toPrevBookmark(SimpleBookmark.class));
-            assertTrue(m_xc.isAtSamePositionAs(xc0));
-            assertNull(m_xc.toPrevBookmark(SimpleBookmark.class));
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.END);
+            m_xc.setBookmark(_theBookmark1);
+            try (XmlCursor xc1 = m_xc.newCursor()) {
+                m_xc.toEndDoc();
+
+                assertEquals(_theBookmark1, m_xc.toPrevBookmark(SimpleBookmark.class));
+                assertTrue(m_xc.isAtSamePositionAs(xc1));
+                assertEquals(_theBookmark, m_xc.toPrevBookmark(SimpleBookmark.class));
+                assertTrue(m_xc.isAtSamePositionAs(xc0));
+                assertNull(m_xc.toPrevBookmark(SimpleBookmark.class));
+            }
         }
     }
 
@@ -72,20 +70,19 @@ public class ToPrevBookmarkTest extends BasicCursorTestCase {
         m_xc = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.START);
         m_xc.setBookmark(_theBookmark);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.END);
-        m_xc.setBookmark(_difBookmark);
-        XmlCursor xc1 = m_xc.newCursor();
-        m_xc.toEndDoc();
-        try {
-            assertEquals(_difBookmark, m_xc.toPrevBookmark(DifferentBookmark.class));
-            assertTrue(m_xc.isAtSamePositionAs(xc1));
-            assertNull(m_xc.toPrevBookmark(DifferentBookmark.class));
-            assertEquals(_theBookmark, m_xc.toPrevBookmark(SimpleBookmark.class));
-            assertTrue(m_xc.isAtSamePositionAs(xc0));
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.END);
+            m_xc.setBookmark(_difBookmark);
+
+            try (XmlCursor xc1 = m_xc.newCursor()) {
+                m_xc.toEndDoc();
+
+                assertEquals(_difBookmark, m_xc.toPrevBookmark(DifferentBookmark.class));
+                assertTrue(m_xc.isAtSamePositionAs(xc1));
+                assertNull(m_xc.toPrevBookmark(DifferentBookmark.class));
+                assertEquals(_theBookmark, m_xc.toPrevBookmark(SimpleBookmark.class));
+                assertTrue(m_xc.isAtSamePositionAs(xc0));
+            }
         }
     }
 
@@ -97,16 +94,14 @@ public class ToPrevBookmarkTest extends BasicCursorTestCase {
         m_xc.toNextChar(2);
         assertEquals("xt", m_xc.getChars());
         m_xc.setBookmark(_theBookmark);   // set bm in middle of TEXT
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toEndDoc();
-        m_xc.toPrevToken();
-        m_xc.setTextValue("changed");  // changes text, should destroy bm
-        m_xc.toEndDoc();
-        try {
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toEndDoc();
+            m_xc.toPrevToken();
+            m_xc.setTextValue("changed");  // changes text, should destroy bm
+            m_xc.toEndDoc();
+
             assertNull(xc1.toPrevBookmark(SimpleBookmark.class));
             assertEquals(TokenType.ENDDOC, xc1.currentTokenType());
-        } finally {
-            xc1.dispose();
         }
     }
 

--- a/src/test/java/xmlcursor/checkin/ToPrevElementTest.java
+++ b/src/test/java/xmlcursor/checkin/ToPrevElementTest.java
@@ -36,14 +36,12 @@ public class ToPrevElementTest extends BasicCursorTestCase {
     @Test
     public void testToPrevElementFromENDDOC() throws Exception {
         m_xc = XmlObject.Factory.parse("<foo>early<bar>text</bar></foo>").newCursor();
-        XmlCursor xc0 = m_xc.newCursor();
-        xc0.toFirstChild();
-        m_xc.toEndDoc();
-        m_xc.toPrevSibling();
-        try {
+        try (XmlCursor xc0 = m_xc.newCursor()) {
+            xc0.toFirstChild();
+            m_xc.toEndDoc();
+            m_xc.toPrevSibling();
+
             assertTrue(m_xc.isAtSamePositionAs(xc0));
-        } finally {
-            xc0.dispose();
         }
     }
 

--- a/src/test/java/xmlcursor/common/BasicCursorTestCase.java
+++ b/src/test/java/xmlcursor/common/BasicCursorTestCase.java
@@ -33,7 +33,7 @@ public class BasicCursorTestCase {
     public void tearDown() throws Exception {
         m_xo = null;
         if (m_xc != null) {
-            m_xc.dispose();
+            m_xc.close();
             m_xc = null;
         }
     }
@@ -50,6 +50,11 @@ public class BasicCursorTestCase {
                 fail("Expected Token not found! " + tt.toString());
         }
         assertEquals(tt, xc.currentTokenType());
+    }
+
+    public XmlCursor toNextTokenOfTypeCursor(XmlCursor xc, TokenType tt) throws IllegalArgumentException {
+        toNextTokenOfType(xc, tt);
+        return xc.newCursor();
     }
 
     public void toPrevTokenOfType(XmlCursor xc, TokenType tt)

--- a/src/test/java/xmlcursor/detailed/CopyCharsTest.java
+++ b/src/test/java/xmlcursor/detailed/CopyCharsTest.java
@@ -38,11 +38,8 @@ public class CopyCharsTest extends BasicCursorTestCase {
     public void testCopyCharsNegative() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT);
+            XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
             assertFalse(xc0.isAtSamePositionAs(xc1));
             assertEquals(4, xc1.copyChars(-1, xc0));
             assertEquals(TokenType.TEXT, xc0.currentTokenType());
@@ -54,9 +51,6 @@ public class CopyCharsTest extends BasicCursorTestCase {
             assertEquals(TokenType.TEXT, xc1.currentTokenType());
             assertEquals(TokenType.START, xc1.prevTokenType());
             assertEquals("WXYZ", xc1.getTextValue());
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -64,11 +58,8 @@ public class CopyCharsTest extends BasicCursorTestCase {
     public void testCopyCharsZero() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT);
+            XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
             assertFalse(xc0.isAtSamePositionAs(xc1));
             assertEquals(0, xc1.copyChars(0, xc0));
             assertEquals("0123", xc0.getTextValue());
@@ -76,9 +67,6 @@ public class CopyCharsTest extends BasicCursorTestCase {
             assertEquals("0123", xc0.getTextValue());
             assertEquals(TokenType.TEXT, xc1.currentTokenType());
             assertEquals("WXYZ", xc1.getTextValue());
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -86,19 +74,14 @@ public class CopyCharsTest extends BasicCursorTestCase {
     public void testCopyCharsThis() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc0 = m_xc.newCursor();
-        XmlCursor xc1 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT);
+            XmlCursor xc1 = m_xc.newCursor()) {
             assertTrue(xc0.isAtSamePositionAs(xc1));
             assertEquals(4, xc1.copyChars(4, xc0));
             assertEquals("0123", xc0.getTextValue());
             xc0.toPrevToken();
             assertEquals("01230123", xc0.getTextValue());
             assertEquals("0123", xc1.getTextValue());
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -106,11 +89,8 @@ public class CopyCharsTest extends BasicCursorTestCase {
     public void testCopyCharsGTmax() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo><bar>0123</bar><bar>WXYZ</bar></foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc0 = m_xc.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        try {
+        try (XmlCursor xc0 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT);
+            XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
             assertFalse(xc0.isAtSamePositionAs(xc1));
             assertEquals(4, xc1.copyChars(1000, xc0));
             // verify xc0
@@ -119,9 +99,6 @@ public class CopyCharsTest extends BasicCursorTestCase {
             assertEquals("WXYZ0123", xc0.getTextValue());
             // verify xc1
             assertEquals("WXYZ", xc1.getTextValue());
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -130,14 +107,14 @@ public class CopyCharsTest extends BasicCursorTestCase {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_DIGITS);
         m_xc = m_xo.newCursor();
         XmlObject xo = XmlObject.Factory.parse(Common.XML_FOO_2ATTR_TEXT);
-        XmlCursor xc1 = xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        toNextTokenOfType(xc1, TokenType.TEXT);
-        assertEquals(5, m_xc.copyChars(5, xc1));
-        assertEquals(5,xc1.toPrevChar(5));
-        // verify xc1
-        assertEquals("01234text", xc1.getTextValue());
-        xc1.dispose();
+        try (XmlCursor xc1 = xo.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.TEXT);
+            toNextTokenOfType(xc1, TokenType.TEXT);
+            assertEquals(5, m_xc.copyChars(5, xc1));
+            assertEquals(5,xc1.toPrevChar(5));
+            // verify xc1
+            assertEquals("01234text", xc1.getTextValue());
+        }
         // verify m_xc
         assertEquals("01234", m_xc.getTextValue());
     }
@@ -147,9 +124,10 @@ public class CopyCharsTest extends BasicCursorTestCase {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_DIGITS);
         m_xc = m_xo.newCursor();
         XmlObject xo = XmlObject.Factory.newInstance();
-        XmlCursor xc1 = xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        assertEquals(5, m_xc.copyChars(5, xc1));
+        try (XmlCursor xc1 = xo.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.TEXT);
+            assertEquals(5, m_xc.copyChars(5, xc1));
+        }
     }
 }
 

--- a/src/test/java/xmlcursor/detailed/CopyTest.java
+++ b/src/test/java/xmlcursor/detailed/CopyTest.java
@@ -30,19 +30,18 @@ public class CopyTest {
     public void testCopyNamespaceMigration() throws XmlException {
         String s1 = "<X xmlns=\"foo\" xmlns:xsi=\"bar\"><zzz>123</zzz></X>";
         String s2 = "<Y> ... [some content] ... </Y>";
-        XmlCursor xc1 = XmlObject.Factory.parse(s1).newCursor();
-        xc1.toFirstContentToken();
-        xc1.toFirstChild();
-        XmlCursor xc2 = XmlObject.Factory.parse(s2).newCursor();
-        assertEquals(XmlCursor.TokenType.START, xc2.toFirstContentToken());
-        xc2.toNextToken();
-        xc1.copyXml(xc2);
-        xc2.toStartDoc();
-        assertEquals("<Y>" +
-                     "<foo:zzz xmlns:foo=\"foo\" xmlns:xsi=\"bar\">123</foo:zzz>" +
-                     " ... [some content] ... </Y>", xc2.xmlText());
-        xc1.dispose();
-        xc2.dispose();
+        try (XmlCursor xc1 = XmlObject.Factory.parse(s1).newCursor();
+            XmlCursor xc2 = XmlObject.Factory.parse(s2).newCursor()) {
+            xc1.toFirstContentToken();
+            xc1.toFirstChild();
+            assertEquals(XmlCursor.TokenType.START, xc2.toFirstContentToken());
+            xc2.toNextToken();
+            xc1.copyXml(xc2);
+            xc2.toStartDoc();
+            assertEquals("<Y>" +
+                         "<foo:zzz xmlns:foo=\"foo\" xmlns:xsi=\"bar\">123</foo:zzz>" +
+                         " ... [some content] ... </Y>", xc2.xmlText());
+        }
     }
 
 }

--- a/src/test/java/xmlcursor/detailed/CursorGeneratedTypedObjectTest.java
+++ b/src/test/java/xmlcursor/detailed/CursorGeneratedTypedObjectTest.java
@@ -45,50 +45,47 @@ public class CursorGeneratedTypedObjectTest {
             "<loc:StateCode>TX</loc:StateCode>" +
             "</loc:Location>";
         LocationDocument locDoc = LocationDocument.Factory.parse(sXml);
-        XmlCursor xc = locDoc.newCursor();
-        xc.toFirstChild();
-        LocationDocument.Location loc = (LocationDocument.Location) xc.getObject();
-        assertTrue(loc.validate());
-        XmlCursor xc0 = xc.newCursor();
-
-        xc0.toEndDoc();
-        xc0.toPrevToken();
-        //  xc0.insertElementWithText("SubdivisionCode", "xyz");
-        xc0.insertElementWithText(
-            new QName("http://xbean.test/xmlcursor/Location", "SubdivisionCode", "loc"),
-            "xyz");
-        xc0.toCursor(xc);
-
-
-        String sExpectedXML =
-            "<loc:Location " + sNamespace + ">" +
-            "<loc:CityName>DALLAS</loc:CityName>" +
-            "<loc:StateCode>TX</loc:StateCode>" +
-            "<loc:SubdivisionCode>xyz</loc:SubdivisionCode>" +
-            "</loc:Location>";
-
-        String sOExpectedXML =
-            "<xml-fragment " + sNamespace + ">" +
-            "<loc:CityName>DALLAS</loc:CityName>" +
-            "<loc:StateCode>TX</loc:StateCode>" +
-            "<loc:SubdivisionCode>xyz</loc:SubdivisionCode>" +
-            "</xml-fragment>";
-        XmlOptions map = new XmlOptions();
-        //map.put(XmlOptions.SAVE_PRETTY_PRINT, "");
-        //map.put(XmlOptions.SAVE_PRETTY_PRINT_INDENT, new Integer(-1));
-        try {
-            assertEquals(sExpectedXML, xc0.xmlText(map));
-            loc = (LocationDocument.Location) xc0.getObject();
-            assertEquals(sOExpectedXML, loc.xmlText());
+        try (XmlCursor xc = locDoc.newCursor()) {
+            xc.toFirstChild();
+            LocationDocument.Location loc = (LocationDocument.Location) xc.getObject();
             assertTrue(loc.validate());
-            assertEquals("DALLAS", loc.getCityName());
-            assertEquals("TX", loc.getStateCode());
-            assertEquals("xyz", loc.getSubdivisionCode());
-        } finally {
-            xc.dispose();
-            xc0.dispose();
-        }
 
+            try (XmlCursor xc0 = xc.newCursor()) {
+                xc0.toEndDoc();
+                xc0.toPrevToken();
+                //  xc0.insertElementWithText("SubdivisionCode", "xyz");
+                xc0.insertElementWithText(
+                    new QName("http://xbean.test/xmlcursor/Location", "SubdivisionCode", "loc"),
+                    "xyz");
+                xc0.toCursor(xc);
+
+
+                String sExpectedXML =
+                    "<loc:Location " + sNamespace + ">" +
+                    "<loc:CityName>DALLAS</loc:CityName>" +
+                    "<loc:StateCode>TX</loc:StateCode>" +
+                    "<loc:SubdivisionCode>xyz</loc:SubdivisionCode>" +
+                    "</loc:Location>";
+
+                String sOExpectedXML =
+                    "<xml-fragment " + sNamespace + ">" +
+                    "<loc:CityName>DALLAS</loc:CityName>" +
+                    "<loc:StateCode>TX</loc:StateCode>" +
+                    "<loc:SubdivisionCode>xyz</loc:SubdivisionCode>" +
+                    "</xml-fragment>";
+                XmlOptions map = new XmlOptions();
+                //map.put(XmlOptions.SAVE_PRETTY_PRINT, "");
+                //map.put(XmlOptions.SAVE_PRETTY_PRINT_INDENT, new Integer(-1));
+
+                assertEquals(sExpectedXML, xc0.xmlText(map));
+                loc = (LocationDocument.Location) xc0.getObject();
+                assertEquals(sOExpectedXML, loc.xmlText());
+                assertTrue(loc.validate());
+                assertEquals("DALLAS", loc.getCityName());
+                assertEquals("TX", loc.getStateCode());
+                assertEquals("xyz", loc.getSubdivisionCode());
+            }
+        }
     }
 
     @Test
@@ -97,71 +94,68 @@ public class CursorGeneratedTypedObjectTest {
         CarLocationMessageDocument clm = CarLocationMessageDocument.Factory.parse(
             JarUtil.getResourceFromJar(
                 Common.TRANXML_FILE_CLM));
-        XmlCursor xc = clm.newCursor();
-        xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT +
-                      "$this//GeographicLocation");
-        xc.toNextSelection();
+        try (XmlCursor xc = clm.newCursor()) {
+            xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT +
+                          "$this//GeographicLocation");
+            xc.toNextSelection();
 
-        GeographicLocationDocument.GeographicLocation gl0 = (GeographicLocationDocument.GeographicLocation) xc.getObject();
-        assertTrue(gl0.validate());
+            GeographicLocationDocument.GeographicLocation gl0 = (GeographicLocationDocument.GeographicLocation) xc.getObject();
+            assertTrue(gl0.validate());
 
-        XmlCursor xc0 = xc.newCursor();
-        try {
-            xc0.toLastChild();
-            assertEquals("TX", xc0.getTextValue());
-            xc0.toNextToken();
-            xc0.toNextToken();
-            xc0.toNextToken();
-            xc0.toNextToken();
-            assertEquals(TokenType.END, xc0.currentTokenType());
+            try (XmlCursor xc0 = xc.newCursor()) {
+                xc0.toLastChild();
+                assertEquals("TX", xc0.getTextValue());
+                xc0.toNextToken();
+                xc0.toNextToken();
+                xc0.toNextToken();
+                xc0.toNextToken();
+                assertEquals(TokenType.END, xc0.currentTokenType());
 
-            xc0.beginElement("LocationIdentifier",
-                "http://www.tranxml.org/TranXML/Version4.0");
-            xc0.insertAttributeWithValue("Qualifier", "FR");
-            xc0.toEndToken();
-            xc0.toNextToken();//move past the end token
-            xc0.insertElementWithText("CountrySubdivisionCode",
-                "http://www.tranxml.org/TranXML/Version4.0", "xyz");
-            xc0.toCursor(xc);
+                xc0.beginElement("LocationIdentifier",
+                    "http://www.tranxml.org/TranXML/Version4.0");
+                xc0.insertAttributeWithValue("Qualifier", "FR");
+                xc0.toEndToken();
+                xc0.toNextToken();//move past the end token
+                xc0.insertElementWithText("CountrySubdivisionCode",
+                    "http://www.tranxml.org/TranXML/Version4.0", "xyz");
+                xc0.toCursor(xc);
 
-            String sExpectedXML =
-                "<GeographicLocation " + sNamespace + ">\n" +
-                "\t\t\t<CityName>DALLAS</CityName>\n" +
-                "\t\t\t<StateOrProvinceCode>TX</StateOrProvinceCode>\n" +
-                "\t\t<LocationIdentifier Qualifier=\"FR\"/><CountrySubdivisionCode>xyz</CountrySubdivisionCode>" +
-                "</GeographicLocation>";
+                String sExpectedXML =
+                    "<GeographicLocation " + sNamespace + ">\n" +
+                    "\t\t\t<CityName>DALLAS</CityName>\n" +
+                    "\t\t\t<StateOrProvinceCode>TX</StateOrProvinceCode>\n" +
+                    "\t\t<LocationIdentifier Qualifier=\"FR\"/><CountrySubdivisionCode>xyz</CountrySubdivisionCode>" +
+                    "</GeographicLocation>";
 
-            XmlOptions map = new XmlOptions();
-            //  map.put(XmlOptions.SAVE_PRETTY_PRINT, "");
-            //  map.put(XmlOptions.SAVE_PRETTY_PRINT_INDENT, new Integer(-1));
-            assertEquals(sExpectedXML, xc0.xmlText());
+                XmlOptions map = new XmlOptions();
+                //  map.put(XmlOptions.SAVE_PRETTY_PRINT, "");
+                //  map.put(XmlOptions.SAVE_PRETTY_PRINT_INDENT, new Integer(-1));
+                assertEquals(sExpectedXML, xc0.xmlText());
 
-            String sOExpectedXML =
-                "<xml-fragment xmlns:xsi=\"http://www.w3.org/2000/10/XMLSchema-instance\">\n" +
-                "\t\t\t<ver:CityName xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\">" +
-                "DALLAS</ver:CityName>\n" +
-                "\t\t\t<ver:StateOrProvinceCode xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\">" +
-                "TX</ver:StateOrProvinceCode>\n" +
-                "\t\t<ver:LocationIdentifier Qualifier=\"FR\" " +
-                "xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\"/>" +
-                "<ver:CountrySubdivisionCode xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\">xyz" +
-                "</ver:CountrySubdivisionCode></xml-fragment>";
+                String sOExpectedXML =
+                    "<xml-fragment xmlns:xsi=\"http://www.w3.org/2000/10/XMLSchema-instance\">\n" +
+                    "\t\t\t<ver:CityName xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\">" +
+                    "DALLAS</ver:CityName>\n" +
+                    "\t\t\t<ver:StateOrProvinceCode xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\">" +
+                    "TX</ver:StateOrProvinceCode>\n" +
+                    "\t\t<ver:LocationIdentifier Qualifier=\"FR\" " +
+                    "xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\"/>" +
+                    "<ver:CountrySubdivisionCode xmlns:ver=\"http://www.tranxml.org/TranXML/Version4.0\">xyz" +
+                    "</ver:CountrySubdivisionCode></xml-fragment>";
 
-            GeographicLocationDocument.GeographicLocation gl = (GeographicLocationDocument.GeographicLocation) xc0.getObject();
-            assertEquals(sOExpectedXML, gl.xmlText(map));
-            assertTrue(gl.validate());
+                GeographicLocationDocument.GeographicLocation gl = (GeographicLocationDocument.GeographicLocation) xc0.getObject();
+                assertEquals(sOExpectedXML, gl.xmlText(map));
+                assertTrue(gl.validate());
 
 
-            assertEquals("DALLAS", gl.getCityName().getStringValue());
-            assertEquals("TX", gl.getStateOrProvinceCode());
-            LocationIdentifierDocument.LocationIdentifier li = gl.getLocationIdentifier();
-            assertNotNull("LocationIdentifier unexpectedly null", li);
-            assertEquals(CodeList309.FR,
-                gl.getLocationIdentifier().getQualifier());
-            assertEquals("xyz", gl.getCountrySubdivisionCode());
-        } finally {
-            xc.dispose();
-            xc0.dispose();
+                assertEquals("DALLAS", gl.getCityName().getStringValue());
+                assertEquals("TX", gl.getStateOrProvinceCode());
+                LocationIdentifierDocument.LocationIdentifier li = gl.getLocationIdentifier();
+                assertNotNull("LocationIdentifier unexpectedly null", li);
+                assertEquals(CodeList309.FR,
+                    gl.getLocationIdentifier().getQualifier());
+                assertEquals("xyz", gl.getCountrySubdivisionCode());
+            }
         }
     }
 
@@ -171,37 +165,34 @@ public class CursorGeneratedTypedObjectTest {
         String sFF = "<First>Fred</First><Last>Flintstone</Last>";
         String sXml = "<Person xmlns=\"person\"><Name>" + sFF +
                       "</Name></Person>";
-        XmlCursor xc = XmlObject.Factory.parse(sXml).newCursor();
-        PersonDocument pdoc = (PersonDocument) xc.getObject();
+        try (XmlCursor xc = XmlObject.Factory.parse(sXml).newCursor()) {
+            PersonDocument pdoc = (PersonDocument) xc.getObject();
 
-        xc.toFirstChild();
-        XmlCursor xcPlaceHolder = xc.newCursor();
+            xc.toFirstChild();
 
-        try {
-            Person p = (Person) xc.getObject();
-            assertTrue(p.validate());
-            // move to </Person>
-            xc.toEndToken();
+            try (XmlCursor xcPlaceHolder = xc.newCursor()) {
+                Person p = (Person) xc.getObject();
+                assertTrue(p.validate());
+                // move to </Person>
+                xc.toEndToken();
 
-            xc.insertElement("Sibling", "person");
-            xc.toPrevToken();
-            xc.insertElement("Name", "person");
-            xc.toPrevToken();
-            xc.insertElementWithText("First", "person", "Barney");
-            xc.insertElementWithText("Last", "person", "Rubble");
+                xc.insertElement("Sibling", "person");
+                xc.toPrevToken();
+                xc.insertElement("Name", "person");
+                xc.toPrevToken();
+                xc.insertElementWithText("First", "person", "Barney");
+                xc.insertElementWithText("Last", "person", "Rubble");
 
-            p = (Person) xcPlaceHolder.getObject();
-            assertTrue(p.validate());
+                p = (Person) xcPlaceHolder.getObject();
+                assertTrue(p.validate());
 
-            assertEquals("Fred", p.getName().getFirst());
-            assertEquals("Flintstone", p.getName().getLast());
-            Person[] ap = p.getSiblingArray();
-            assertEquals(1, ap.length);
-            assertEquals("Barney", ap[0].getName().getFirst());
-            assertEquals("Rubble", ap[0].getName().getLast());
-        } finally {
-            xc.dispose();
-            xcPlaceHolder.dispose();
+                assertEquals("Fred", p.getName().getFirst());
+                assertEquals("Flintstone", p.getName().getLast());
+                Person[] ap = p.getSiblingArray();
+                assertEquals(1, ap.length);
+                assertEquals("Barney", ap[0].getName().getFirst());
+                assertEquals("Rubble", ap[0].getName().getLast());
+            }
         }
     }
 }

--- a/src/test/java/xmlcursor/detailed/CursorVsObjectAttributeTest.java
+++ b/src/test/java/xmlcursor/detailed/CursorVsObjectAttributeTest.java
@@ -37,15 +37,16 @@ public class CursorVsObjectAttributeTest {
     public void testAttributeSet() throws Exception {
         CarLocationMessageDocument clmDoc = CarLocationMessageDocument.Factory.parse(
             JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
-        XmlCursor xc = clmDoc.newCursor();
-        xc.toFirstChild();
-        CarLocationMessage clm = (CarLocationMessage) xc.getObject();
+        try (XmlCursor xc = clmDoc.newCursor()) {
+            xc.toFirstChild();
+            CarLocationMessage clm = (CarLocationMessage) xc.getObject();
 
-        clm.setVersion("XyZ");
-        QName name = new QName("Version");
-        assertEquals("XyZ", xc.getAttributeText(name));
-        xc.setAttributeText(name, "012");
-        assertEquals("012", clm.getVersion());
+            clm.setVersion("XyZ");
+            QName name = new QName("Version");
+            assertEquals("XyZ", xc.getAttributeText(name));
+            xc.setAttributeText(name, "012");
+            assertEquals("012", clm.getVersion());
+        }
     }
 
     @Test
@@ -53,17 +54,18 @@ public class CursorVsObjectAttributeTest {
         CarLocationMessageDocument clmDoc =
             (CarLocationMessageDocument) XmlObject.Factory.parse(
                 JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
-        XmlCursor xc = clmDoc.newCursor();
-        xc.toFirstChild();
-        CarLocationMessage clm = (CarLocationMessage) xc.getObject();
-        QName name = new QName("Version");
-        assertEquals("CLM", xc.getAttributeText(name));
-        clm.unsetVersion();
-        assertNull(xc.getAttributeText(name));
-        xc.setAttributeText(name, "012");
-        assertEquals("012", clm.getVersion());
-        xc.removeAttribute(name);
-        assertNull(clm.getVersion());
+        try (XmlCursor xc = clmDoc.newCursor()) {
+            xc.toFirstChild();
+            CarLocationMessage clm = (CarLocationMessage) xc.getObject();
+            QName name = new QName("Version");
+            assertEquals("CLM", xc.getAttributeText(name));
+            clm.unsetVersion();
+            assertNull(xc.getAttributeText(name));
+            xc.setAttributeText(name, "012");
+            assertEquals("012", clm.getVersion());
+            xc.removeAttribute(name);
+            assertNull(clm.getVersion());
+        }
     }
 
     @Test
@@ -74,16 +76,17 @@ public class CursorVsObjectAttributeTest {
         CarLocationMessageDocument clmDoc =
             (CarLocationMessageDocument) XmlObject.Factory.parse(
                 JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM), map);
-        XmlCursor xc = clmDoc.newCursor();
-        xc.toFirstChild();
-        CarLocationMessage clm = (CarLocationMessage) xc.getObject();
-        QName name = new QName("Version");
-        assertEquals("CLM", xc.getAttributeText(name));
-        clm.unsetVersion();
-        assertNull(xc.getAttributeText(name));
-        xc.toFirstChild();
-        assertEquals(TokenType.START, xc.currentTokenType());
-        xc.insertAttributeWithValue(name, "012");
-        assertEquals("012", clm.getVersion());
+        try (XmlCursor xc = clmDoc.newCursor()) {
+            xc.toFirstChild();
+            CarLocationMessage clm = (CarLocationMessage) xc.getObject();
+            QName name = new QName("Version");
+            assertEquals("CLM", xc.getAttributeText(name));
+            clm.unsetVersion();
+            assertNull(xc.getAttributeText(name));
+            xc.toFirstChild();
+            assertEquals(TokenType.START, xc.currentTokenType());
+            xc.insertAttributeWithValue(name, "012");
+            assertEquals("012", clm.getVersion());
+        }
     }
 }

--- a/src/test/java/xmlcursor/detailed/CursorVsObjectInsertRemoveTest.java
+++ b/src/test/java/xmlcursor/detailed/CursorVsObjectInsertRemoveTest.java
@@ -35,31 +35,35 @@ public class CursorVsObjectInsertRemoveTest {
             (CarLocationMessageDocument) XmlObject.Factory.parse(
                 JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
         assertNotNull(clm);
-        XmlCursor xc = clm.newCursor();
-        xc.toFirstChild();
-        xc.toFirstChild();
-        xc.toNextSibling();
-        xc.toNextSibling();
-        assertEquals("EventStatus", xc.getName().getLocalPart());
-        EventStatus eventStatus = (EventStatus) xc.getObject();
-        assertNotNull("Expected non-null EventStatus object", eventStatus);
-        String sEventStatusText = xc.getTextValue();
-        GeographicLocation glDest = eventStatus.getDestination().getGeographicLocation();
-        assertNotNull("Expected non-null GeographicLocation object", glDest);
-        glDest.setPostalCode("90210");
-        glDest.setCountryCode("US");
-        try (XmlCursor xcPostalCode = glDest.xgetPostalCode().newCursor();
-            XmlCursor xcCountryCode = glDest.xgetCountryCode().newCursor()) {
-            assertEquals("90210", xcPostalCode.getTextValue());
-            assertEquals("US", xcCountryCode.getTextValue());
-            xcPostalCode.setTextValue("90310");
-            xcPostalCode.toNextChar(2);
-            assertEquals("90310", glDest.getPostalCode());
-            eventStatus.getDestination().getGeographicLocation().unsetPostalCode();
-            assertEquals(TokenType.START, xcPostalCode.currentTokenType());
-            assertEquals("CountryCode", xcPostalCode.getName().getLocalPart());
-            xcCountryCode.removeXml();
-            assertEquals(sEventStatusText, xc.getTextValue());
+        try (XmlCursor xc = clm.newCursor()) {
+            xc.toFirstChild();
+            xc.toFirstChild();
+            xc.toNextSibling();
+            xc.toNextSibling();
+            assertEquals("EventStatus", xc.getName().getLocalPart());
+            EventStatus eventStatus;
+            eventStatus = (EventStatus) xc.getObject();
+            assertNotNull("Expected non-null EventStatus object", eventStatus);
+            String sEventStatusText;
+            sEventStatusText = xc.getTextValue();
+
+            GeographicLocation glDest = eventStatus.getDestination().getGeographicLocation();
+            assertNotNull("Expected non-null GeographicLocation object", glDest);
+            glDest.setPostalCode("90210");
+            glDest.setCountryCode("US");
+            try (XmlCursor xcPostalCode = glDest.xgetPostalCode().newCursor();
+                XmlCursor xcCountryCode = glDest.xgetCountryCode().newCursor()) {
+                assertEquals("90210", xcPostalCode.getTextValue());
+                assertEquals("US", xcCountryCode.getTextValue());
+                xcPostalCode.setTextValue("90310");
+                xcPostalCode.toNextChar(2);
+                assertEquals("90310", glDest.getPostalCode());
+                eventStatus.getDestination().getGeographicLocation().unsetPostalCode();
+                assertEquals(TokenType.START, xcPostalCode.currentTokenType());
+                assertEquals("CountryCode", xcPostalCode.getName().getLocalPart());
+                xcCountryCode.removeXml();
+                assertEquals(sEventStatusText, xc.getTextValue());
+            }
         }
     }
 

--- a/src/test/java/xmlcursor/detailed/CursorVsObjectInsertRemoveTest.java
+++ b/src/test/java/xmlcursor/detailed/CursorVsObjectInsertRemoveTest.java
@@ -48,9 +48,8 @@ public class CursorVsObjectInsertRemoveTest {
         assertNotNull("Expected non-null GeographicLocation object", glDest);
         glDest.setPostalCode("90210");
         glDest.setCountryCode("US");
-        XmlCursor xcPostalCode = glDest.xgetPostalCode().newCursor();
-        XmlCursor xcCountryCode = glDest.xgetCountryCode().newCursor();
-        try {
+        try (XmlCursor xcPostalCode = glDest.xgetPostalCode().newCursor();
+            XmlCursor xcCountryCode = glDest.xgetCountryCode().newCursor()) {
             assertEquals("90210", xcPostalCode.getTextValue());
             assertEquals("US", xcCountryCode.getTextValue());
             xcPostalCode.setTextValue("90310");
@@ -61,9 +60,6 @@ public class CursorVsObjectInsertRemoveTest {
             assertEquals("CountryCode", xcPostalCode.getName().getLocalPart());
             xcCountryCode.removeXml();
             assertEquals(sEventStatusText, xc.getTextValue());
-        } finally {
-            xcPostalCode.dispose();
-            xcCountryCode.dispose();
         }
     }
 

--- a/src/test/java/xmlcursor/detailed/CursorVsObjectSetGetTextTest.java
+++ b/src/test/java/xmlcursor/detailed/CursorVsObjectSetGetTextTest.java
@@ -35,10 +35,9 @@ public class CursorVsObjectSetGetTextTest {
                 (CarLocationMessageDocument) XmlObject.Factory.parse(
                         JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
         assertNotNull(clm);
-        XmlCursor xc = clm.newCursor();
         GeographicLocation[] aGL = new GeographicLocation[3];
 
-        try {
+        try (XmlCursor xc = clm.newCursor()) {
             xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT +
                           "$this//GeographicLocation");
             xc.toNextSelection();
@@ -67,8 +66,6 @@ public class CursorVsObjectSetGetTextTest {
             for (int i = 0; i < 3; i++) {
                 assertEquals("PORTLAND", aGL[i].getCityName().getStringValue());
             }
-        } finally {
-            xc.dispose();
         }
     }
 

--- a/src/test/java/xmlcursor/detailed/MoveXmlTest2.java
+++ b/src/test/java/xmlcursor/detailed/MoveXmlTest2.java
@@ -112,21 +112,21 @@ public class MoveXmlTest2 extends BasicCursorTestCase
     public void testMovedAttrNameCollision() throws Exception
     {
 
-        m_xc1 = XmlObject.Factory.parse(sTestXml).newCursor();
-        toNextTokenOfType(m_xc, TokenType.START);//m_xc on book at0
-        toNextTokenOfType(m_xc1, TokenType.START);
-        toNextTokenOfType(m_xc1, TokenType.START);
-        //toNextTokenOfType(m_xc1,TokenType.END);//to author
-        assertTrue(m_xc1.toFirstAttribute());
-        assertTrue(m_xc.toFirstAttribute()); //at0 in book
-        if (m_xc.moveXml(m_xc1)) {
-            toPrevTokenOfType(m_xc1, TokenType.START);
-            m_xc1.toFirstAttribute();
-            assertEquals(m_xc1.getName().getLocalPart(), "at0");
-            assertTrue(m_xc1.toNextAttribute());
-            assertEquals(m_xc1.getName().getLocalPart(), "at0");
+        try (XmlCursor m_xc2 = XmlObject.Factory.parse(sTestXml).newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.START);//m_xc on book at0
+            toNextTokenOfType(m_xc2, TokenType.START);
+            toNextTokenOfType(m_xc2, TokenType.START);
+            //toNextTokenOfType(m_xc2,TokenType.END);//to author
+            assertTrue(m_xc2.toFirstAttribute());
+            assertTrue(m_xc.toFirstAttribute()); //at0 in book
+            if (m_xc.moveXml(m_xc2)) {
+                toPrevTokenOfType(m_xc2, TokenType.START);
+                m_xc2.toFirstAttribute();
+                assertEquals(m_xc2.getName().getLocalPart(), "at0");
+                assertTrue(m_xc2.toNextAttribute());
+                assertEquals(m_xc2.getName().getLocalPart(), "at0");
+            }
         }
-        m_xc1.dispose();
     }
 
     /**
@@ -183,7 +183,7 @@ public class MoveXmlTest2 extends BasicCursorTestCase
     {
         super.tearDown();
         if (m_xc1 != null) {
-            m_xc1.dispose();
+            m_xc1.close();
             m_xc1 = null;
         }
     }

--- a/src/test/java/xmlcursor/detailed/MultipleCopyFromCursorTest.java
+++ b/src/test/java/xmlcursor/detailed/MultipleCopyFromCursorTest.java
@@ -42,9 +42,8 @@ public class MultipleCopyFromCursorTest {
             (CarLocationMessageDocument) XmlObject.Factory.parse(
                 JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
         assertNotNull(clm);
-        XmlCursor xc = clm.newCursor();
         XmlCursor[] aCursors = new XmlCursor[3];
-        try {
+        try (XmlCursor xc = clm.newCursor()) {
             xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT +
                           "$this//GeographicLocation");
             xc.toNextSelection();
@@ -119,9 +118,8 @@ public class MultipleCopyFromCursorTest {
             }
 
         } finally {
-            xc.dispose();
             for (int i = 0; i < 3; i++) {
-                aCursors[i].dispose();
+                aCursors[i].close();
             }
         }
     }

--- a/src/test/java/xmlcursor/detailed/MultipleCopyTest.java
+++ b/src/test/java/xmlcursor/detailed/MultipleCopyTest.java
@@ -36,9 +36,8 @@ public class MultipleCopyTest {
             (CarLocationMessageDocument) XmlObject.Factory.parse(
                 JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
         assertNotNull(clm);
-        XmlCursor xc = clm.newCursor();
         XmlCursor[] aCursors = new XmlCursor[3];
-        try {
+        try (XmlCursor xc = clm.newCursor()) {
             xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT +
                           "$this//GeographicLocation");
             xc.toNextSelection();
@@ -70,9 +69,8 @@ public class MultipleCopyTest {
                 assertEquals("xyz", gl.getCountrySubdivisionCode());
             }
         } finally {
-            xc.dispose();
             for (int i = 0; i < 3; i++) {
-                aCursors[i].dispose();
+                aCursors[i].close();
             }
         }
     }

--- a/src/test/java/xmlcursor/detailed/MultipleCursorSetTest.java
+++ b/src/test/java/xmlcursor/detailed/MultipleCursorSetTest.java
@@ -30,18 +30,20 @@ import static org.junit.Assert.*;
 public class MultipleCursorSetTest {
     @Test
     public void testMultipleCursorSet() throws Exception {
-        XmlCursor xc = XmlObject.Factory.parse(JarUtil.getResourceFromJar(
-                Common.TRANXML_FILE_CLM)).newCursor();
-        xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT +
-                      "$this//EquipmentNumber");
-        xc.toNextSelection();
-        XmlString xs = (XmlString) xc.getObject();
-        assertEquals("123456", xs.getStringValue());
-        assertEquals(TokenType.TEXT, xc.toNextToken());
         XmlCursor[] aCursors = new XmlCursor[6];
-        for (int i = 0; i < 6; i++) {
-            xc.toNextChar(1);
-            aCursors[i] = xc.newCursor();
+        XmlString xs;
+        try (XmlCursor xc = XmlObject.Factory.parse(JarUtil.getResourceFromJar(
+                    Common.TRANXML_FILE_CLM)).newCursor()) {
+            xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT +
+                          "$this//EquipmentNumber");
+            xc.toNextSelection();
+            xs = (XmlString) xc.getObject();
+            assertEquals("123456", xs.getStringValue());
+            assertEquals(TokenType.TEXT, xc.toNextToken());
+            for (int i = 0; i < 6; i++) {
+                xc.toNextChar(1);
+                aCursors[i] = xc.newCursor();
+            }
         }
         for (int i = 0; i < 6; i++) {
             for (int j = 0; j != i && j < 6; j++) {

--- a/src/test/java/xmlcursor/detailed/ObjectCursorInteractionTest.java
+++ b/src/test/java/xmlcursor/detailed/ObjectCursorInteractionTest.java
@@ -39,21 +39,18 @@ public class ObjectCursorInteractionTest {
         // LocationDocument locDoc = (LocationDocument) XmlObject.Factory.parse(sXml);
         LocationDocument locDoc = LocationDocument.Factory.parse(sXml);
         Location loc = locDoc.getLocation();
-        XmlCursor xc0 = loc.newCursor();
-        assertEquals("DALLAS", loc.getCityName());
-        loc = null;
-        System.gc();
-        try {
+        try (XmlCursor xc0 = loc.newCursor()) {
+            assertEquals("DALLAS", loc.getCityName());
+            loc = null;
+            System.gc();
             Thread.sleep(1000);
             xc0.toFirstChild();
             assertEquals("DALLAS", xc0.getTextValue());
-        } finally {
-            xc0.dispose();
         }
     }
 
     @Test
-    public void testCursorDisposalEffectOnObject() throws Exception {
+    public void testCursorCloseEffectOnObject() throws Exception {
         String sNamespace = "xmlns:loc=\"http://xbean.test/xmlcursor/Location\"";
         String sXml = "<loc:Location " + sNamespace + ">" +
                       "<loc:CityName>DALLAS</loc:CityName><loc:StateCode>TX</loc:StateCode></loc:Location>";
@@ -62,23 +59,20 @@ public class ObjectCursorInteractionTest {
         assertTrue(locDoc.validate());
         Location loc0 = locDoc.getLocation();
         Location loc1 = locDoc.getLocation();
-        XmlCursor xc0 = loc0.newCursor();
-        XmlCursor xc1 = loc1.newCursor();
 
-        xc0.toFirstChild();
-        xc1.toFirstChild();
-        xc0.setTextValue("AUSTIN");
-        try {
+        try (XmlCursor xc0 = loc0.newCursor();
+            XmlCursor xc1 = loc1.newCursor()) {
+            xc0.toFirstChild();
+            xc1.toFirstChild();
+            xc0.setTextValue("AUSTIN");
+
             assertEquals("AUSTIN", loc0.getCityName());
             loc1.setCityName("SAN ANTONIO");
-            xc0.dispose();
+            xc0.close();
             assertEquals("SAN ANTONIO", xc1.getTextValue());
             xc1.setTextValue("HOUSTON");
-            xc1.dispose();
+            xc1.close();
             assertEquals("HOUSTON", loc0.getCityName());
-        } finally {
-            xc0.dispose();
-            xc1.dispose();
         }
     }
 
@@ -120,7 +114,7 @@ public class ObjectCursorInteractionTest {
             xc0 = loc0.newCursor();
             assertEquals(sXml1, xc0.xmlText());
         } finally {
-            xc0.dispose();
+            xc0.close();
         }
     }
 
@@ -167,8 +161,8 @@ public class ObjectCursorInteractionTest {
             assertEquals("US", loc0.getCountryCode());
 
         } finally {
-            xc0.dispose();
-            xc1.dispose();
+            xc0.close();
+            xc1.close();
         }
     }
 

--- a/src/test/java/xmlcursor/detailed/SelectionsTest.java
+++ b/src/test/java/xmlcursor/detailed/SelectionsTest.java
@@ -35,34 +35,35 @@ public class SelectionsTest extends BasicCursorTestCase {
     //average case test
 	@Test
 	public void testNormalCase() throws Exception {
-		XmlCursor m_xc1 = m_xo.newCursor();
-		int nSelectionsCount = 7;
-		m_xc.selectPath("$this//a");
-		assertFalse(m_xc.hasNextSelection());
-		assertFalse(m_xc.toNextSelection());
-		assertEquals(0, m_xc.getSelectionCount());
+	    try (XmlCursor m_xc1 = m_xo.newCursor()) {
+    		int nSelectionsCount = 7;
+    		m_xc.selectPath("$this//a");
+    		assertFalse(m_xc.hasNextSelection());
+    		assertFalse(m_xc.toNextSelection());
+    		assertEquals(0, m_xc.getSelectionCount());
 
-		m_xc.selectPath("$this//b");
-		m_xc1.toFirstChild();
-		m_xc1.toFirstChild();
-		do {
-			m_xc1.addToSelection();
-		} while (m_xc1.toNextSibling());
-		assertEquals(nSelectionsCount, m_xc.getSelectionCount());
-		int i = 0;
-		while (m_xc.hasNextSelection()) {
-			m_xc.toNextSelection();
-			assertEquals("" + i, m_xc.getTextValue());
-			i++;
-		}
-		int j = 0;
-		while (m_xc1.hasNextSelection()) {
-			m_xc1.toSelection(j);
-			assertEquals("" + j, m_xc1.getTextValue());
-			j++;
-		}
-		assertEquals(nSelectionsCount, j);
-		assertEquals(nSelectionsCount, i);
+    		m_xc.selectPath("$this//b");
+    		m_xc1.toFirstChild();
+    		m_xc1.toFirstChild();
+    		do {
+    			m_xc1.addToSelection();
+    		} while (m_xc1.toNextSibling());
+    		assertEquals(nSelectionsCount, m_xc.getSelectionCount());
+    		int i = 0;
+    		while (m_xc.hasNextSelection()) {
+    			m_xc.toNextSelection();
+    			assertEquals("" + i, m_xc.getTextValue());
+    			i++;
+    		}
+    		int j = 0;
+    		while (m_xc1.hasNextSelection()) {
+    			m_xc1.toSelection(j);
+    			assertEquals("" + j, m_xc1.getTextValue());
+    			j++;
+    		}
+    		assertEquals(nSelectionsCount, j);
+    		assertEquals(nSelectionsCount, i);
+	    }
 	}
 
 	@Test

--- a/src/test/java/xmlcursor/detailed/SelectionsTest.java
+++ b/src/test/java/xmlcursor/detailed/SelectionsTest.java
@@ -108,21 +108,19 @@ public class SelectionsTest extends BasicCursorTestCase {
 			"declare namespace ns='http://xbean.test/xmlcursor/CR196679'" +
 				"$this/ns:value";
 
-		XmlCursor cursor = test.newCursor();
-		cursor.push();
-		cursor.selectPath(queryName);
-		cursor.toNextSelection();
+		try (XmlCursor cursor = test.newCursor()) {
+    		cursor.push();
+    		cursor.selectPath(queryName);
+    		cursor.toNextSelection();
 
-		assertEquals("myTest", cursor.getTextValue());
+    		assertEquals("myTest", cursor.getTextValue());
 
-		cursor.pop();
-		cursor.selectPath(queryValue);
-		cursor.toNextSelection();
+    		cursor.pop();
+    		cursor.selectPath(queryValue);
+    		cursor.toNextSelection();
 
-		assertEquals("5", cursor.getTextValue());//expected output is value=5
-
-		cursor.dispose();
-
+    		assertEquals("5", cursor.getTextValue());//expected output is value=5
+		}
 	}
 
 	@Before

--- a/src/test/java/xmlcursor/detailed/ToBookmarkTest.java
+++ b/src/test/java/xmlcursor/detailed/ToBookmarkTest.java
@@ -39,15 +39,13 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         m_xc = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.START);
         m_xc.setBookmark(_theBookmark);
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toEndDoc();
-        assertTrue(xc1.toBookmark(_theBookmark));
-        try {
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toEndDoc();
+            assertTrue(xc1.toBookmark(_theBookmark));
+
             assertTrue(m_xc.isAtSamePositionAs(xc1));
             SimpleBookmark sa = (SimpleBookmark) xc1.getBookmark(_theBookmark.getClass());
             assertEquals("value", sa.text);
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -57,15 +55,13 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         m_xc = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.START);
         m_xc.setBookmark(_theBookmark);
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toStartDoc();
-        assertTrue(xc1.toBookmark(_theBookmark));
-        try {
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toStartDoc();
+            assertTrue(xc1.toBookmark(_theBookmark));
+
             assertTrue(m_xc.isAtSamePositionAs(xc1));
             SimpleBookmark sa = (SimpleBookmark) xc1.getBookmark(_theBookmark.getClass());
             assertEquals("value", sa.text);
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -75,14 +71,12 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         m_xc = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.START);
         m_xc.setBookmark(_theBookmark);
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toEndDoc();
-        assertFalse(xc1.toBookmark(null));
-        try {
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toEndDoc();
+            assertFalse(xc1.toBookmark(null));
+
             assertFalse(m_xc.isAtSamePositionAs(xc1));
             assertEquals(TokenType.ENDDOC, xc1.currentTokenType());
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -91,15 +85,13 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_TEXT);
         m_xc = m_xo.newCursor();
         XmlObject xo = XmlObject.Factory.parse(Common.XML_FOO);
-        XmlCursor xc1 = xo.newCursor();
-        assertFalse(m_xc.isInSameDocument(xc1));
-        toNextTokenOfType(m_xc, TokenType.START);
-        m_xc.setBookmark(_theBookmark);
-        try {
+        try (XmlCursor xc1 = xo.newCursor()) {
+            assertFalse(m_xc.isInSameDocument(xc1));
+            toNextTokenOfType(m_xc, TokenType.START);
+            m_xc.setBookmark(_theBookmark);
+
             assertFalse(xc1.toBookmark(_theBookmark));
             assertFalse(m_xc.isInSameDocument(xc1));
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -110,23 +102,23 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         String exp_ns = "xmlns:po=\"http://xbean.test/xmlcursor/PurchaseOrder\"";
 
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        m_xc.selectPath(ns + " $this//po:shipTo/po:city");
-        while (m_xc.toNextSelection()) {
-            m_xc.setBookmark(_theBookmark);
-            xc1.selectPath(ns + " $this//po:billTo/po:city");
-            while (xc1.toNextSelection()) {
-                m_xc.moveXml(xc1);
-                try {
-                    assertTrue(xc1.toBookmark(_theBookmark));
-                    assertEquals("<po:city " + exp_ns + ">Mill Valley</po:city>", xc1.xmlText());
-                    xc1.toNextSibling();
-                    assertEquals("<po:city " + exp_ns + ">Old Town</po:city>", xc1.xmlText());
-                } catch (Exception e) {
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            m_xc.selectPath(ns + " $this//po:shipTo/po:city");
+            while (m_xc.toNextSelection()) {
+                m_xc.setBookmark(_theBookmark);
+                xc1.selectPath(ns + " $this//po:billTo/po:city");
+                while (xc1.toNextSelection()) {
+                    m_xc.moveXml(xc1);
+                    try {
+                        assertTrue(xc1.toBookmark(_theBookmark));
+                        assertEquals("<po:city " + exp_ns + ">Mill Valley</po:city>", xc1.xmlText());
+                        xc1.toNextSibling();
+                        assertEquals("<po:city " + exp_ns + ">Old Town</po:city>", xc1.xmlText());
+                    } catch (Exception e) {
+                    }
                 }
             }
         }
-        xc1.dispose();
     }
 
     @Test
@@ -136,76 +128,74 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         String exp_ns = "xmlns:po=\"http://xbean.test/xmlcursor/PurchaseOrder\"";
 
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        m_xc.selectPath(ns + " $this//po:shipTo/po:city");
-        while (m_xc.toNextSelection()) {
-            m_xc.setBookmark(_theBookmark);
-            toNextTokenOfType(m_xc, TokenType.TEXT);
-            m_xc.toNextToken();
-            m_xc.toNextToken();  // move to behind the <city>Mill Valley</city> element
-            assertEquals(TokenType.TEXT, m_xc.currentTokenType());
-            m_xc.setBookmark(_theBookmark1);
-            m_xc.toBookmark(_theBookmark);
-            xc1.selectPath(ns + " $this//po:billTo/po:city");
-            while (xc1.toNextSelection()) {
-                m_xc.moveXml(xc1);
-                m_xc.toStartDoc();
-                try {
-                    assertTrue(xc1.toBookmark(_theBookmark1));
-                    xc1.toPrevSibling();
-                    assertEquals("<po:street " + exp_ns + ">123 Maple Street</po:street>", xc1.xmlText());
-                } catch (Exception e) {
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            m_xc.selectPath(ns + " $this//po:shipTo/po:city");
+            while (m_xc.toNextSelection()) {
+                m_xc.setBookmark(_theBookmark);
+                toNextTokenOfType(m_xc, TokenType.TEXT);
+                m_xc.toNextToken();
+                m_xc.toNextToken();  // move to behind the <city>Mill Valley</city> element
+                assertEquals(TokenType.TEXT, m_xc.currentTokenType());
+                m_xc.setBookmark(_theBookmark1);
+                m_xc.toBookmark(_theBookmark);
+                xc1.selectPath(ns + " $this//po:billTo/po:city");
+                while (xc1.toNextSelection()) {
+                    m_xc.moveXml(xc1);
+                    m_xc.toStartDoc();
+                    try {
+                        assertTrue(xc1.toBookmark(_theBookmark1));
+                        xc1.toPrevSibling();
+                        assertEquals("<po:street " + exp_ns + ">123 Maple Street</po:street>", xc1.xmlText());
+                    } catch (Exception e) {
+                    }
                 }
             }
         }
-        xc1.dispose();
     }
 
     @Test
     public void testToBookmarkPostCopy() throws Exception {
         m_xo = XmlObject.Factory.parse(JarUtil.getResourceFromJar(Common.TRANXML_FILE_XMLCURSOR_PO));
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        String ns = "declare namespace po=\"http://xbean.test/xmlcursor/PurchaseOrder\"";
-        String exp_ns = "xmlns:po=\"http://xbean.test/xmlcursor/PurchaseOrder\"";
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            String ns = "declare namespace po=\"http://xbean.test/xmlcursor/PurchaseOrder\"";
+            String exp_ns = "xmlns:po=\"http://xbean.test/xmlcursor/PurchaseOrder\"";
 
-        m_xc.selectPath(ns + " $this//po:shipTo/po:city");
-        while (m_xc.toNextSelection()) {
-            m_xc.setBookmark(_theBookmark);
-            xc1.selectPath(ns + "$this//po:billTo/po:city");
-            while (xc1.toNextSelection()) {
-                m_xc.copyXml(xc1);
-                try {
-                    assertTrue(xc1.toBookmark(_theBookmark));
-                    assertEquals("<po:city " + exp_ns + ">Mill Valley</po:city>", xc1.xmlText());
-                    xc1.toNextSibling();
-                    assertEquals("<po:state " + exp_ns + ">CA</po:state>", xc1.xmlText());
-                } catch (Exception e) {
+            m_xc.selectPath(ns + " $this//po:shipTo/po:city");
+            while (m_xc.toNextSelection()) {
+                m_xc.setBookmark(_theBookmark);
+                xc1.selectPath(ns + "$this//po:billTo/po:city");
+                while (xc1.toNextSelection()) {
+                    m_xc.copyXml(xc1);
+                    try {
+                        assertTrue(xc1.toBookmark(_theBookmark));
+                        assertEquals("<po:city " + exp_ns + ">Mill Valley</po:city>", xc1.xmlText());
+                        xc1.toNextSibling();
+                        assertEquals("<po:state " + exp_ns + ">CA</po:state>", xc1.xmlText());
+                    } catch (Exception e) {
+                    }
                 }
             }
         }
-        xc1.dispose();
     }
 
     @Test
     public void testToBookmarkPostMoveChars() throws Exception {
         m_xo = XmlObject.Factory.parse(Common.XML_FOO_DIGITS);
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        xc1.toCursor(m_xc);
-        xc1.toNextChar(1);
-        xc1.setBookmark(_theBookmark);  // set an Bookmark at the '1'
-        xc1.toNextChar(2);  // move xc1 to the '3'
-        try {
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            toNextTokenOfType(m_xc, TokenType.TEXT);
+            xc1.toCursor(m_xc);
+            xc1.toNextChar(1);
+            xc1.setBookmark(_theBookmark);  // set an Bookmark at the '1'
+            xc1.toNextChar(2);  // move xc1 to the '3'
+
             assertEquals("34", xc1.getTextValue());
             assertEquals(2, m_xc.moveChars(2, xc1));
             assertEquals("20134", m_xc.getTextValue());
             assertEquals("34", xc1.getTextValue());
             xc1.toBookmark(_theBookmark);
             assertEquals("134", xc1.getTextValue());
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -220,14 +210,14 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         m_xc = m_xo.newCursor();
         // XmlCursor xc1 = m_xo.newCursor();
         toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        //xc1.toCursor(m_xc);
-        xc1.toNextChar(1);
-        // set a Bookmark at the '1', text is 1234
-        xc1.setBookmark(_theBookmark);
-        // move xc1 to the '3' , text post cursor is 34
-        xc1.toNextChar(2);
-        try {
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            //xc1.toCursor(m_xc);
+            xc1.toNextChar(1);
+            // set a Bookmark at the '1', text is 1234
+            xc1.setBookmark(_theBookmark);
+            // move xc1 to the '3' , text post cursor is 34
+            xc1.toNextChar(2);
+
             assertEquals("34", xc1.getTextValue());
             //text at m_xc is 01234, should get 0123*01*4
             assertEquals(2, m_xc.copyChars(2, xc1));
@@ -235,8 +225,6 @@ public class ToBookmarkTest extends BasicCursorTestCase {
             assertEquals("34", xc1.getTextValue());
             xc1.toBookmark(_theBookmark);
             assertEquals("120134", xc1.getTextValue());
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -244,32 +232,32 @@ public class ToBookmarkTest extends BasicCursorTestCase {
     public void testDumb() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo>01234</foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toNextChar(2);
-        assertEquals(2, m_xc.copyChars(2, xc1));
+        try (XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
+            xc1.toNextChar(2);
+            assertEquals(2, m_xc.copyChars(2, xc1));
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testDumbDelete() throws Exception {
         m_xo = XmlObject.Factory.parse("<foo>01234</foo>");
         m_xc = m_xo.newCursor();
-        toNextTokenOfType(m_xc, TokenType.TEXT);
-        XmlCursor xc1 = m_xc.newCursor();
-        m_xc.toNextChar(2);
-        m_xc.setBookmark(_theBookmark);
-        m_xc.toStartDoc();
-        //remove the text , bookmark goes bye bye too
-        xc1.removeXml();
-        xc1.toCursor(m_xc);
-        //both at start of original doc
-        assertEquals(m_xc.currentTokenType(),
-                XmlCursor.TokenType.STARTDOC);
-        assertTrue(m_xc.isAtSamePositionAs(xc1));
-        //move xc1 to outer space
-        xc1.toBookmark(_theBookmark);
-        assertTrue(!m_xc.isInSameDocument(xc1));
-        assertTrue(!m_xc.isLeftOf(xc1));
+        try (XmlCursor xc1 = toNextTokenOfTypeCursor(m_xc, TokenType.TEXT)) {
+            m_xc.toNextChar(2);
+            m_xc.setBookmark(_theBookmark);
+            m_xc.toStartDoc();
+            //remove the text , bookmark goes bye bye too
+            xc1.removeXml();
+            xc1.toCursor(m_xc);
+            //both at start of original doc
+            assertEquals(m_xc.currentTokenType(),
+                    XmlCursor.TokenType.STARTDOC);
+            assertTrue(m_xc.isAtSamePositionAs(xc1));
+            //move xc1 to outer space
+            xc1.toBookmark(_theBookmark);
+            assertTrue(!m_xc.isInSameDocument(xc1));
+            assertTrue(!m_xc.isLeftOf(xc1));
+        }
     }
 
     @Test
@@ -282,26 +270,26 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         m_xc.toNextToken();
         m_xc.setBookmark(_theBookmark);  // set annot. at 'text'
 
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toBookmark(_theBookmark);
-        SimpleBookmark sa = (SimpleBookmark) xc1.getBookmark(SimpleBookmark.class);
-        assertEquals("value", sa.text);
-        m_xc.toStartDoc();
-        xc1.toPrevToken();
-        xc1.removeXml();
-        xc1.toStartDoc();
-        assertTrue(m_xc.isAtSamePositionAs(xc1));
-        assertEquals("<foo/>", m_xc.xmlText());
-        //test modified, the two cursors are not in the same
-        //tree anymore
-        assertTrue(xc1.toBookmark(_theBookmark));
-        assertTrue(!xc1.isInSameDocument(m_xc));
-//        assertTrue(!xc1.isLeftOf(m_xc));
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toBookmark(_theBookmark);
+            SimpleBookmark sa = (SimpleBookmark) xc1.getBookmark(SimpleBookmark.class);
+            assertEquals("value", sa.text);
+            m_xc.toStartDoc();
+            xc1.toPrevToken();
+            xc1.removeXml();
+            xc1.toStartDoc();
+            assertTrue(m_xc.isAtSamePositionAs(xc1));
+            assertEquals("<foo/>", m_xc.xmlText());
+            //test modified, the two cursors are not in the same
+            //tree anymore
+            assertTrue(xc1.toBookmark(_theBookmark));
+            assertTrue(!xc1.isInSameDocument(m_xc));
+//            assertTrue(!xc1.isLeftOf(m_xc));
 
-        sa = (SimpleBookmark) xc1.getBookmark(SimpleBookmark.class);
-        assertNotNull(sa);
-        assertEquals(TokenType.TEXT, xc1.currentTokenType());
-        xc1.dispose();
+            sa = (SimpleBookmark) xc1.getBookmark(SimpleBookmark.class);
+            assertNotNull(sa);
+            assertEquals(TokenType.TEXT, xc1.currentTokenType());
+        }
     }
 
     @Test
@@ -311,21 +299,19 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         toNextTokenOfType(m_xc, TokenType.ATTR);
         m_xc.setBookmark(_theBookmark);  // set annot. at attribute
         m_xc.toStartDoc();
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toBookmark(_theBookmark);
-        SimpleBookmark sa = (SimpleBookmark) xc1.getBookmark(SimpleBookmark.class);
-        assertEquals("value", sa.text);
-        xc1.toEndDoc();
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toBookmark(_theBookmark);
+            SimpleBookmark sa = (SimpleBookmark) xc1.getBookmark(SimpleBookmark.class);
+            assertEquals("value", sa.text);
+            xc1.toEndDoc();
 
-        toNextTokenOfType(m_xc, TokenType.START);
-        m_xc.removeAttribute(new QName("attr0"));
-        m_xc.toStartDoc();
-        try {
+            toNextTokenOfType(m_xc, TokenType.START);
+            m_xc.removeAttribute(new QName("attr0"));
+            m_xc.toStartDoc();
+
             assertEquals("<foo>text</foo>", m_xc.xmlText());
             assertTrue(xc1.toBookmark(_theBookmark));
             assertTrue(!xc1.isInSameDocument(m_xc));
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -340,17 +326,15 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         m_xc.toPrevChar(2);
         assertEquals(3, m_xc.removeChars(3));  // '2' should be deleted
         assertEquals("34", m_xc.getTextValue());
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toEndDoc();
-        try {
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toEndDoc();
+
             assertTrue(xc1.toBookmark(_theBookmark));
             assertTrue(!xc1.isInSameDocument(m_xc));
             SimpleBookmark sa =
                     (SimpleBookmark) xc1.getBookmark(SimpleBookmark.class);
             assertEquals("value", sa.text);
             assertEquals(TokenType.TEXT, xc1.currentTokenType());
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -362,20 +346,18 @@ public class ToBookmarkTest extends BasicCursorTestCase {
         m_xc.toNextChar(2);
         assertEquals("xt", m_xc.getTextValue());
         m_xc.setBookmark(_theBookmark);   // set annot. in middle of TEXT
-        XmlCursor xc1 = m_xc.newCursor();
-        xc1.toEndDoc();
-        m_xc.toPrevToken();
-        m_xc.setTextValue("changed");
-        m_xc.toStartDoc();
-        assertEquals("<foo>changed</foo>", m_xc.xmlText());
-        try {
+        try (XmlCursor xc1 = m_xc.newCursor()) {
+            xc1.toEndDoc();
+            m_xc.toPrevToken();
+            m_xc.setTextValue("changed");
+            m_xc.toStartDoc();
+            assertEquals("<foo>changed</foo>", m_xc.xmlText());
+
             assertTrue(xc1.toBookmark(_theBookmark));
             assertTrue(!xc1.isInSameDocument(m_xc));
             SimpleBookmark sa = (SimpleBookmark) xc1.getBookmark(SimpleBookmark.class);
                assertEquals("value", sa.text);
             assertEquals(TokenType.TEXT, xc1.currentTokenType());
-        } finally {
-            xc1.dispose();
         }
 
     }

--- a/src/test/java/xmlcursor/detailed/XmlLineNumberTest.java
+++ b/src/test/java/xmlcursor/detailed/XmlLineNumberTest.java
@@ -47,20 +47,22 @@ public class XmlLineNumberTest extends Common {
         XmlOptions opt = new XmlOptions();
         opt.setLoadLineNumbers();
         XmlObject xo = XmlObject.Factory.parse(f, opt);
-        XmlCursor c = xo.newCursor();
-        c.toFirstChild();
-        assertEquals(XmlCursor.TokenType.START, c.currentTokenType());
-        XmlLineNumber ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertNotNull(ln);
-        assertEquals(16, ln.getLine());
-        c.toFirstChild();
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(17, ln.getLine());
-        c.toEndToken();
-        assertEquals(XmlCursor.TokenType.END, c.currentTokenType());
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        // no bookmark at END
-        assertNull(ln);
+
+        try (XmlCursor c = xo.newCursor()) {
+            c.toFirstChild();
+            assertEquals(XmlCursor.TokenType.START, c.currentTokenType());
+            XmlLineNumber ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertNotNull(ln);
+            assertEquals(16, ln.getLine());
+            c.toFirstChild();
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(17, ln.getLine());
+            c.toEndToken();
+            assertEquals(XmlCursor.TokenType.END, c.currentTokenType());
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            // no bookmark at END
+            assertNull(ln);
+        }
     }
 
     /**
@@ -73,21 +75,23 @@ public class XmlLineNumberTest extends Common {
         XmlOptions opt = new XmlOptions();
         opt.setLoadLineNumbersEndElement();
         XmlObject xo = XmlObject.Factory.parse(f, opt);
-        XmlCursor c = xo.newCursor();
-        c.toFirstChild();
-        assertEquals(XmlCursor.TokenType.START, c.currentTokenType());
-        XmlLineNumber ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertNotNull(ln);
-        assertEquals(16, ln.getLine());
-        c.toFirstChild();
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(17, ln.getLine());
-        c.toEndToken();
-        assertEquals(XmlCursor.TokenType.END, c.currentTokenType());
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        // there is a bookmark at END
-        assertNotNull(ln);
-        assertEquals(34, ln.getLine());
+
+        try (XmlCursor c = xo.newCursor()) {
+            c.toFirstChild();
+            assertEquals(XmlCursor.TokenType.START, c.currentTokenType());
+            XmlLineNumber ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertNotNull(ln);
+            assertEquals(16, ln.getLine());
+            c.toFirstChild();
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(17, ln.getLine());
+            c.toEndToken();
+            assertEquals(XmlCursor.TokenType.END, c.currentTokenType());
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            // there is a bookmark at END
+            assertNotNull(ln);
+            assertEquals(34, ln.getLine());
+        }
     }
 
     /**
@@ -98,23 +102,25 @@ public class XmlLineNumberTest extends Common {
     public void testLineNumber1() throws Exception {
         XmlOptions opt = new XmlOptions().setLoadLineNumbers();
         XmlObject xo = XmlObject.Factory.parse(xml, opt);
-        XmlCursor c = xo.newCursor();
-        c.toFirstContentToken();
-        c.toFirstChild();
-        XmlLineNumber ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(1, ln.getLine());
-        assertEquals(50, ln.getColumn());
-        // offset is not implemented
-        assertEquals(-1, ln.getOffset());
-        c.toFirstChild();
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(2, ln.getLine());
-        assertEquals(10, ln.getColumn());
-        c.toFirstChild();
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(3, ln.getLine());
-        // finishes after reading after <first_name> + 2xtabs
-        assertEquals(14, ln.getColumn());
+
+        try (XmlCursor c = xo.newCursor()) {
+            c.toFirstContentToken();
+            c.toFirstChild();
+            XmlLineNumber ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(1, ln.getLine());
+            assertEquals(50, ln.getColumn());
+            // offset is not implemented
+            assertEquals(-1, ln.getOffset());
+            c.toFirstChild();
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(2, ln.getLine());
+            assertEquals(10, ln.getColumn());
+            c.toFirstChild();
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(3, ln.getLine());
+            // finishes after reading after <first_name> + 2xtabs
+            assertEquals(14, ln.getColumn());
+        }
     }
 
     /**
@@ -127,28 +133,30 @@ public class XmlLineNumberTest extends Common {
         XmlOptions opt = new XmlOptions();
         opt.setLoadLineNumbersEndElement();
         XmlObject xo = XmlObject.Factory.parse(f, opt);
-        XmlCursor c = xo.newCursor();
-        c.toFirstContentToken();
-        c.toFirstChild();
-        XmlLineNumber ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(17, ln.getLine());
-        assertEquals(15, ln.getColumn());
-        assertEquals(-1, ln.getOffset());
-        c.toFirstChild();
-        c.push();
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(18, ln.getLine());
-        assertEquals(13, ln.getColumn());
-        c.toEndToken();
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(18, ln.getLine());
-        assertEquals(33, ln.getColumn());
-        c.pop();
-        c.toNextSibling(); //address
-        c.toEndToken();
-        ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
-        assertEquals(24, ln.getLine());
-        assertEquals(17, ln.getColumn());
-        assertEquals(-1, ln.getOffset());
+
+        try (XmlCursor c = xo.newCursor()) {
+            c.toFirstContentToken();
+            c.toFirstChild();
+            XmlLineNumber ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(17, ln.getLine());
+            assertEquals(15, ln.getColumn());
+            assertEquals(-1, ln.getOffset());
+            c.toFirstChild();
+            c.push();
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(18, ln.getLine());
+            assertEquals(13, ln.getColumn());
+            c.toEndToken();
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(18, ln.getLine());
+            assertEquals(33, ln.getColumn());
+            c.pop();
+            c.toNextSibling(); //address
+            c.toEndToken();
+            ln = (XmlLineNumber) c.getBookmark(XmlLineNumber.class);
+            assertEquals(24, ln.getLine());
+            assertEquals(17, ln.getColumn());
+            assertEquals(-1, ln.getOffset());
+        }
     }
 }

--- a/src/test/java/xmlcursor/jsr173/common/CharactersTest.java
+++ b/src/test/java/xmlcursor/jsr173/common/CharactersTest.java
@@ -198,21 +198,22 @@ public abstract class CharactersTest {
 
     @Before
     public void setUp() throws Exception {
-        XmlCursor cur = XmlObject.Factory.newInstance().newCursor();
-        cur.toNextToken();
+        try (XmlCursor cur = XmlObject.Factory.newInstance().newCursor()) {
+            cur.toNextToken();
 
-        //   cur.insertAttributeWithValue(new QName("foo.org", "at0", "pre"), "val0");
-        cur.insertComment(" some comment ");
-        cur.beginElement(new QName("foo.org", "foo", ""));
-        cur.insertAttribute("localName");
-        cur.insertChars("some text");
-        cur.insertElement("foo2");
-        cur.toNextToken(); //close foo elt
-        cur.insertChars("\t");
+            //   cur.insertAttributeWithValue(new QName("foo.org", "at0", "pre"), "val0");
+            cur.insertComment(" some comment ");
+            cur.beginElement(new QName("foo.org", "foo", ""));
+            cur.insertAttribute("localName");
+            cur.insertChars("some text");
+            cur.insertElement("foo2");
+            cur.toNextToken(); //close foo elt
+            cur.insertChars("\t");
 
 
-        cur.toStartDoc();
-        m_stream = getStream(cur);
+            cur.toStartDoc();
+            m_stream = getStream(cur);
+        }
     }
 
     @After

--- a/src/test/java/xmlcursor/jsr173/common/GeneralMethodsTest.java
+++ b/src/test/java/xmlcursor/jsr173/common/GeneralMethodsTest.java
@@ -102,27 +102,28 @@ public abstract class GeneralMethodsTest {
 
     @Before
     public void setUp() throws Exception {
-        XmlCursor cur = XmlObject.Factory.newInstance().newCursor();
-        cur.toNextToken();
+        try (XmlCursor cur = XmlObject.Factory.newInstance().newCursor()) {
+            cur.toNextToken();
 
-        cur.insertAttributeWithValue(new QName("foo.org", "at0", "pre"),
-            "val0");
-        cur.insertAttributeWithValue(new QName("", "at1", "pre"), "val1");
-        cur.insertNamespace("pre", "foons.bar.org");
-        cur.beginElement(new QName("foo.org", "foo", ""));
-        cur.insertAttribute("localName");
-        cur.insertChars("some text");
-        cur.toNextToken();
-        cur.toNextToken();//end elt
-        cur.insertProcInst("xml-stylesheet", "http://foobar");
+            cur.insertAttributeWithValue(new QName("foo.org", "at0", "pre"),
+                "val0");
+            cur.insertAttributeWithValue(new QName("", "at1", "pre"), "val1");
+            cur.insertNamespace("pre", "foons.bar.org");
+            cur.beginElement(new QName("foo.org", "foo", ""));
+            cur.insertAttribute("localName");
+            cur.insertChars("some text");
+            cur.toNextToken();
+            cur.toNextToken();//end elt
+            cur.insertProcInst("xml-stylesheet", "http://foobar");
 
-        cur.toStartDoc();
-        XmlDocumentProperties opt = cur.documentProperties();
+            cur.toStartDoc();
+            XmlDocumentProperties opt = cur.documentProperties();
 
-        m_stream1 = getStream(cur);
+            m_stream1 = getStream(cur);
 
-        opt.setEncoding("utf-8");
-        m_stream = getStream(cur);
+            opt.setEncoding("utf-8");
+            m_stream = getStream(cur);
+        }
 
     }
 

--- a/src/test/java/xmlcursor/jsr173/common/IsXXXTest.java
+++ b/src/test/java/xmlcursor/jsr173/common/IsXXXTest.java
@@ -102,25 +102,26 @@ public abstract class IsXXXTest {
 
     @Before
     public void setUp() throws Exception {
-        XmlCursor cur = XmlObject.Factory.newInstance().newCursor();
-        cur.toNextToken();
+        try (XmlCursor cur = XmlObject.Factory.newInstance().newCursor()) {
+            cur.toNextToken();
 
-        cur.insertAttributeWithValue(new QName("foo.org", "at0", "pre"),
-            "val0");
-        cur.insertAttributeWithValue(new QName("", "at1", "pre"), "val1");
-        cur.insertNamespace("pre", "foons.bar.org");
-        cur.beginElement(new QName("foo.org", "foo", ""));
-        cur.insertAttribute("localName");
-        cur.insertChars("some text");
-        cur.toNextToken();
-        cur.toNextToken();//end elt
-        cur.insertProcInst("xml-stylesheet", "http://foobar");
-        cur.insertChars("\t");
-        cur.insertComment(" some comment ");
+            cur.insertAttributeWithValue(new QName("foo.org", "at0", "pre"),
+                "val0");
+            cur.insertAttributeWithValue(new QName("", "at1", "pre"), "val1");
+            cur.insertNamespace("pre", "foons.bar.org");
+            cur.beginElement(new QName("foo.org", "foo", ""));
+            cur.insertAttribute("localName");
+            cur.insertChars("some text");
+            cur.toNextToken();
+            cur.toNextToken();//end elt
+            cur.insertProcInst("xml-stylesheet", "http://foobar");
+            cur.insertChars("\t");
+            cur.insertComment(" some comment ");
 
-        cur.toStartDoc();
+            cur.toStartDoc();
 
-        m_stream = getStream(cur);
+            m_stream = getStream(cur);
+        }
     }
 
     @After

--- a/src/test/java/xmlcursor/jsr173/common/NamespaceTest.java
+++ b/src/test/java/xmlcursor/jsr173/common/NamespaceTest.java
@@ -249,26 +249,27 @@ public abstract class NamespaceTest {
 
     @Before
     public void setUp() throws Exception {
-        XmlCursor cur = XmlObject.Factory.newInstance().newCursor();
-        cur.toNextToken();
+        try (XmlCursor cur = XmlObject.Factory.newInstance().newCursor()) {
+            cur.toNextToken();
 
-        cur.insertAttributeWithValue(new QName("foo.org", "at0", "pre"),
-            "val0");
-        cur.insertNamespace("pre0", "bea.com");
+            cur.insertAttributeWithValue(new QName("foo.org", "at0", "pre"),
+                "val0");
+            cur.insertNamespace("pre0", "bea.com");
 
-        cur.beginElement(new QName("foo.org", "foo", ""));
-        cur.insertNamespace("pre", "foons.bar.org");
-        cur.insertNamespace("pre1", "foons1.bar1.org1");
-        cur.insertChars("some text");
-        cur.toNextToken();
-        cur.toNextToken();//end elt
-        cur.insertProcInst("xml-stylesheet", "http://foobar");
-        cur.insertChars("\t");
-        cur.insertComment(" some comment ");
+            cur.beginElement(new QName("foo.org", "foo", ""));
+            cur.insertNamespace("pre", "foons.bar.org");
+            cur.insertNamespace("pre1", "foons1.bar1.org1");
+            cur.insertChars("some text");
+            cur.toNextToken();
+            cur.toNextToken();//end elt
+            cur.insertProcInst("xml-stylesheet", "http://foobar");
+            cur.insertChars("\t");
+            cur.insertComment(" some comment ");
 
-        cur.toStartDoc();
+            cur.toStartDoc();
 
-        m_stream = getStream(cur);
+            m_stream = getStream(cur);
+        }
     }
 
     @After

--- a/src/test/java/xmlcursor/jsr173/common/PITest.java
+++ b/src/test/java/xmlcursor/jsr173/common/PITest.java
@@ -62,12 +62,13 @@ public abstract class PITest {
 
     @Before
     public void setUp() throws Exception {
-        XmlCursor cur = XmlObject.Factory.newInstance().newCursor();
-        cur.toNextToken();
-        cur.insertProcInst("xml-stylesheet", "http://foobar");
-        cur.insertElement("foobar");
-        cur.toStartDoc();
-        m_stream = getStream(cur);
+        try (XmlCursor cur = XmlObject.Factory.newInstance().newCursor()) {
+            cur.toNextToken();
+            cur.insertProcInst("xml-stylesheet", "http://foobar");
+            cur.insertElement("foobar");
+            cur.toStartDoc();
+            m_stream = getStream(cur);
+        }
     }
 
     @After

--- a/src/test/java/xmlcursor/xpath/common/XPathCommon.java
+++ b/src/test/java/xmlcursor/xpath/common/XPathCommon.java
@@ -96,12 +96,18 @@ public class XPathCommon {
     }
 
     public static void compare(XmlObject rObj, XmlObject rSet) {
-        check(rObj.newCursor(), rSet.newCursor());
+        try (XmlCursor cObj = rObj.newCursor();
+            XmlCursor cSet = rSet.newCursor()) {
+            check(cObj, cSet);
+        }
     }
 
     public static void compare(XmlObject[] rObj, XmlObject[] rSet) {
         for (int i=0; i < Math.min(rObj.length,rSet.length); i++) {
-            check(rObj[i].newCursor(), rSet[i].newCursor());
+            try (XmlCursor cObj = rObj[i].newCursor();
+                XmlCursor cSet = rSet[i].newCursor()) {
+                check(cObj, cSet);
+            }
         }
 
         Assert.assertEquals(rSet.length, rObj.length);
@@ -110,7 +116,9 @@ public class XPathCommon {
     public static void compare(XmlCursor rObj, XmlObject[] rSet) {
         int curLen = rObj.getSelectionCount();
         for (int i=0; i < Math.min(curLen,rSet.length) && rObj.toNextSelection(); i++) {
-            check(rObj, rSet[i].newCursor());
+            try (XmlCursor cSet = rSet[i].newCursor()) {
+                check(rObj, cSet);
+            }
         }
 
         Assert.assertEquals(rSet.length, curLen);

--- a/src/test/java/xmlcursor/xpath/common/XPathFunctionAuxTest.java
+++ b/src/test/java/xmlcursor/xpath/common/XPathFunctionAuxTest.java
@@ -199,44 +199,45 @@ public class XPathFunctionAuxTest extends BasicCursorTestCase {
             "<price at=\"val1\">2</price>" +
             "</bar><bar1>3.00</bar1></foo>";
         m_xc = XmlObject.Factory.parse(sXml).newCursor();
-        XmlCursor _startPos = m_xc.newCursor();
 
-        String sXPath = "boolean(//foo/text())";//"boolean(//foo/text())";
-        m_xc.push();
-        m_xc.selectPath(sXPath);
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
-        m_xc.clearSelections();
+        try (XmlCursor _startPos = m_xc.newCursor()) {
+            String sXPath = "boolean(//foo/text())";//"boolean(//foo/text())";
+            m_xc.push();
+            m_xc.selectPath(sXPath);
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
+            m_xc.clearSelections();
 
-        //need to reset cursor since it's on a bool outside the doc
-        m_xc.pop();
-        //number
-        m_xc.selectPath("boolean(//price/text())");
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("true"), m_xc.xmlText());
-        m_xc.clearSelections();
+            //need to reset cursor since it's on a bool outside the doc
+            m_xc.pop();
+            //number
+            m_xc.selectPath("boolean(//price/text())");
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("true"), m_xc.xmlText());
+            m_xc.clearSelections();
 
 
-        //number
-        assertTrue(m_xc.toCursor(_startPos));
-        //boolean of Nan is false
-        m_xc.selectPath("boolean(number(name(//price[position()=last()])))");
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
-        m_xc.clearSelections();
+            //number
+            assertTrue(m_xc.toCursor(_startPos));
+            //boolean of Nan is false
+            m_xc.selectPath("boolean(number(name(//price[position()=last()])))");
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
+            m_xc.clearSelections();
 
-        //node-set
-        m_xc.toCursor(_startPos);
-        m_xc.selectPath("boolean(//price)");
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("true"), m_xc.xmlText());
-        m_xc.clearSelections();
+            //node-set
+            m_xc.toCursor(_startPos);
+            m_xc.selectPath("boolean(//price)");
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("true"), m_xc.xmlText());
+            m_xc.clearSelections();
 
-        m_xc.toCursor(_startPos);
-        m_xc.selectPath("boolean(//barK)");
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
-        m_xc.clearSelections();
+            m_xc.toCursor(_startPos);
+            m_xc.selectPath("boolean(//barK)");
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
+            m_xc.clearSelections();
+        }
     }
 
     @Test

--- a/src/test/java/xmlcursor/xpath/common/XPathFunctionAuxTest.java
+++ b/src/test/java/xmlcursor/xpath/common/XPathFunctionAuxTest.java
@@ -46,11 +46,11 @@ public class XPathFunctionAuxTest extends BasicCursorTestCase {
         XmlObject[] exXml1 = new XmlObject[]{XmlObject.Factory.parse(ex1R1)};
 
         System.out.println("Test 1: " + ex1Simple);
-        XmlCursor x1 = xDoc.newCursor();
-        x1.selectPath(ex1Simple);
-        XPathCommon.display(x1);
-        XPathCommon.compare(x1, exXml1);
-        x1.dispose();
+        try (XmlCursor x1 = xDoc.newCursor()) {
+            x1.selectPath(ex1Simple);
+            XPathCommon.display(x1);
+            XPathCommon.compare(x1, exXml1);
+        }
     }
 
     @Test

--- a/src/test/java/xmlcursor/xpath/common/XPathFunctionTest.java
+++ b/src/test/java/xmlcursor/xpath/common/XPathFunctionTest.java
@@ -44,31 +44,30 @@ public abstract class XPathFunctionTest extends BaseXPathTest {
         String ex0Simple =getQuery("testFunctionCount",0) ;
         String ex0Simple1 =getQuery("testFunctionCount",1) ;
         System.out.println("Test 0: " + ex0Simple);
-        XmlCursor x0 = XmlObject.Factory.parse(
+        try (XmlCursor x0 = XmlObject.Factory.parse(
                 "<foo><cd>1</cd><cd>2</cd></foo>")
                 .newCursor();
-        XmlCursor x01 = x0.newCursor();
-        /* XmlCursor countCheck = x0.newCursor();
-           countCheck.selectPath("count(.//cd)");
-           countCheck.toNextSelection();
-           System.out.println(" Global count "+countCheck.xmlText());
-        */
-        String sExpectedResult = "<cd>2</cd>" ;
+            XmlCursor x01 = x0.newCursor()) {
+            /* XmlCursor countCheck = x0.newCursor();
+               countCheck.selectPath("count(.//cd)");
+               countCheck.toNextSelection();
+               System.out.println(" Global count "+countCheck.xmlText());
+            */
+            String sExpectedResult = "<cd>2</cd>" ;
 
-        x01.selectPath(ex0Simple1);
-        assertEquals(1, x01.getSelectionCount());
-        x01.toNextSelection();
-        assertEquals(sExpectedResult, x01.xmlText());
-        x01.dispose();
+            x01.selectPath(ex0Simple1);
+            assertEquals(1, x01.getSelectionCount());
+            x01.toNextSelection();
+            assertEquals(sExpectedResult, x01.xmlText());
 
-        sExpectedResult = "<xml-fragment>2</xml-fragment>";
-        x0.selectPath(ex0Simple);
-        XPathCommon.display(x0);
-        assertEquals(1, x0.getSelectionCount());
-        x0.toNextSelection();
-        //XPathCommon.compare(x0, new XmlObject[]{XmlObject.Factory.parse("<a>foo</a>")});
-        assertEquals(sExpectedResult, x0.xmlText());
-        x0.dispose();
+            sExpectedResult = "<xml-fragment>2</xml-fragment>";
+            x0.selectPath(ex0Simple);
+            XPathCommon.display(x0);
+            assertEquals(1, x0.getSelectionCount());
+            x0.toNextSelection();
+            //XPathCommon.compare(x0, new XmlObject[]{XmlObject.Factory.parse("<a>foo</a>")});
+            assertEquals(sExpectedResult, x0.xmlText());
+        }
 
     }
 
@@ -98,30 +97,30 @@ public abstract class XPathFunctionTest extends BaseXPathTest {
 
 
         System.out.println("Test 1: " + ex1Simple);
-        XmlCursor x1 = xDoc.newCursor();
-        x1.toChild("catalog");
-        System.out.println(x1.currentTokenType());
-        System.out.println(x1.getName());
-        x1.selectPath(ex1Simple);
-        //XPathCommon.display(x1);
-        //assertEquals(1,x1.getSelectionCount());
-        XPathCommon.compare(x1, exXml1);
-        //assertEquals(ex1R1, x1.xmlText());
-        x1.dispose();
+        try (XmlCursor x1 = xDoc.newCursor()) {
+            x1.toChild("catalog");
+            System.out.println(x1.currentTokenType());
+            System.out.println(x1.getName());
+            x1.selectPath(ex1Simple);
+            //XPathCommon.display(x1);
+            //assertEquals(1,x1.getSelectionCount());
+            XPathCommon.compare(x1, exXml1);
+            //assertEquals(ex1R1, x1.xmlText());
+        }
 
         System.out.println("Test 2: " + ex2Simple);
-        XmlCursor x2 = xDoc.newCursor();
-        x2.selectPath(ex2Simple);
-        XPathCommon.display(x2);
-        assertFalse(x2.toNextSelection());
-        x2.dispose();
+        try (XmlCursor x2 = xDoc.newCursor()) {
+            x2.selectPath(ex2Simple);
+            XPathCommon.display(x2);
+            assertFalse(x2.toNextSelection());
+        }
 
         System.out.println("Test 3: " + ex3Simple);
-        XmlCursor x3 = xDoc.newCursor();
-        x3.selectPath(ex3Simple);
-        XPathCommon.display(x3);
-        XPathCommon.compare(x3, exXml3);
-        x3.dispose();
+        try (XmlCursor x3 = xDoc.newCursor()) {
+            x3.selectPath(ex3Simple);
+            XPathCommon.display(x3);
+            XPathCommon.compare(x3, exXml3);
+        }
     }
 
     /**
@@ -143,11 +142,11 @@ public abstract class XPathFunctionTest extends BaseXPathTest {
         XmlObject[] exXml1 = new XmlObject[]{XmlObject.Factory.parse(ex1R1)};
 
         System.out.println("Test 1: " + ex1Simple);
-        XmlCursor x1 = xDoc.newCursor();
-        x1.selectPath(ex1Simple);
-        XPathCommon.display(x1);
-        XPathCommon.compare(x1, exXml1);
-        x1.dispose();
+        try (XmlCursor x1 = xDoc.newCursor()) {
+            x1.selectPath(ex1Simple);
+            XPathCommon.display(x1);
+            XPathCommon.compare(x1, exXml1);
+        }
     }
 
     /**

--- a/src/test/java/xmlcursor/xpath/complex/checkin/ContainerCommentTest.java
+++ b/src/test/java/xmlcursor/xpath/complex/checkin/ContainerCommentTest.java
@@ -47,23 +47,25 @@ public class ContainerCommentTest {
         String m_namespaceDeclaration =
             "declare namespace xq='http://xmlbeans.apache.org/samples/xquery/employees';";
 
-        XmlCursor cursor = employees.newCursor();
-        cursor.toNextToken();
+        try (XmlCursor cursor = employees.newCursor()) {
+            cursor.toNextToken();
 
-        cursor.selectPath(m_namespaceDeclaration + "$this//xq:employee");
-        if (cursor.getSelectionCount() > 0) {
-            cursor.toNextSelection();
-
-            String[] names = new String[cursor.getSelectionCount()];
-
-            for (int i = 0; i < cursor.getSelectionCount(); i++) {
-                XmlCursor nameCursor = cursor.newCursor();
-                nameCursor.selectPath(m_namespaceDeclaration +
-                                      "$this/xq:name/text()");
-                nameCursor.toNextSelection();
-                names[i] = nameCursor.getTextValue();
+            cursor.selectPath(m_namespaceDeclaration + "$this//xq:employee");
+            if (cursor.getSelectionCount() > 0) {
                 cursor.toNextSelection();
-                System.out.println(names[i]);
+
+                String[] names = new String[cursor.getSelectionCount()];
+
+                for (int i = 0; i < cursor.getSelectionCount(); i++) {
+                    try (XmlCursor nameCursor = cursor.newCursor()) {
+                        nameCursor.selectPath(m_namespaceDeclaration +
+                                              "$this/xq:name/text()");
+                        nameCursor.toNextSelection();
+                        names[i] = nameCursor.getTextValue();
+                    }
+                    cursor.toNextSelection();
+                    System.out.println(names[i]);
+                }
             }
         }
     }

--- a/src/test/java/xmlcursor/xpath/complex/checkin/XPathTests.java
+++ b/src/test/java/xmlcursor/xpath/complex/checkin/XPathTests.java
@@ -125,8 +125,7 @@ public class XPathTests {
 
     @Test
     public void testConformance() {
-        XmlCursor actual = doc.newCursor();
-        try {
+        try (XmlCursor actual = doc.newCursor()) {
             actual.selectPath(xpath);
 
             if (actual.getSelectionCount() == 0) {
@@ -136,8 +135,6 @@ public class XPathTests {
 
             XmlObject[] expXO = Stream.of(expected).map(XPathTests::parse).toArray(XmlObject[]::new);
             XPathCommon.compare(actual, expXO);
-        } finally {
-            actual.dispose();
         }
     }
 

--- a/src/test/java/xmlcursor/xpath/complex/checkin/XPathTestsMisc.java
+++ b/src/test/java/xmlcursor/xpath/complex/checkin/XPathTestsMisc.java
@@ -25,10 +25,11 @@ public class XPathTestsMisc {
     public void testDelete() throws Exception {
         String query = "*";
 
-        XmlCursor xc = XmlObject.Factory.parse(XPathTests.XML).newCursor();
-        xc.selectPath(query);
-        while (xc.toNextSelection()) {
-            System.out.println(xc.xmlText());
+        try (XmlCursor xc = XmlObject.Factory.parse(XPathTests.XML).newCursor()) {
+            xc.selectPath(query);
+            while (xc.toNextSelection()) {
+                System.out.println(xc.xmlText());
+            }
         }
     }
 

--- a/src/test/java/xmlcursor/xpath/complex/detailed/DeclareNamespaceTest.java
+++ b/src/test/java/xmlcursor/xpath/complex/detailed/DeclareNamespaceTest.java
@@ -37,18 +37,21 @@ public class DeclareNamespaceTest {
         //"for $e in ./a return <doc>{ $e } </doc>"
         */
         String query = "declare namespace ack='abc'; .//@ack:attr";
-        XmlCursor s1 = s.newCursor();
-        s1.selectPath(query);
-        assertEquals(1, s1.getSelectionCount());
-        s1.toNextSelection();
-        assertEquals(s1.xmlText(),
-            "<xml-fragment ack:attr=\"val1\" xmlns:ack=\"abc\"/>");
+        try (XmlCursor s1 = s.newCursor()) {
+            s1.selectPath(query);
+            assertEquals(1, s1.getSelectionCount());
+            s1.toNextSelection();
+            assertEquals(s1.xmlText(),
+                "<xml-fragment ack:attr=\"val1\" xmlns:ack=\"abc\"/>");
+        }
 
         res = s.execQuery(query);
-        XmlCursor c1 = s.newCursor();
-        c1.toFirstContentToken();
+        XmlObject o;
+        try (XmlCursor c1 = s.newCursor()) {
+            c1.toFirstContentToken();
+            o = c1.getObject();
+        }
 
-        XmlObject o = c1.getObject();
         assertNotSame(o, res[0]);
         assertEquals(res[0].xmlText(),
             "<xml-fragment ack:attr=\"val1\" xmlns:ack=\"abc\"/>");
@@ -69,12 +72,12 @@ public class DeclareNamespaceTest {
         assertEquals( s1.xmlText(),"<b xmlns=\"abc\">bar</b>");
         */
         res = s.execQuery(query);
-        XmlCursor c1 = s.newCursor();
-        c1.toFirstContentToken();
-
-        XmlObject o = c1.getObject();
-        assertNotSame(o, res[0]);
-        assertEquals(res[0].xmlText(), "<abc:b xmlns:abc=\"abc\">bar</abc:b>");
+        try (XmlCursor c1 = s.newCursor()) {
+            c1.toFirstContentToken();
+            XmlObject o = c1.getObject();
+            assertNotSame(o, res[0]);
+            assertEquals(res[0].xmlText(), "<abc:b xmlns:abc=\"abc\">bar</abc:b>");
+        }
     }
 
     @Test
@@ -120,22 +123,24 @@ public class DeclareNamespaceTest {
 
     @Test
     public void testSequenceIntersect() throws Exception {
-        XmlCursor o = XmlObject.Factory.parse("<a><b>1</b>1</a>").newCursor();
-        o.selectPath("//b intersect //b");
-        assertEquals(1, o.getSelectionCount());
-        o.toNextSelection();
-        assertEquals("<b>1</b>", o.xmlText());
+        try (XmlCursor o = XmlObject.Factory.parse("<a><b>1</b>1</a>").newCursor()) {
+            o.selectPath("//b intersect //b");
+            assertEquals(1, o.getSelectionCount());
+            o.toNextSelection();
+            assertEquals("<b>1</b>", o.xmlText());
+        }
     }
 
     @Test
     public void testSequenceExcept() throws Exception {
-        XmlCursor o = XmlObject.Factory.parse("<a><b>1</b>1</a>").newCursor();
-        o.selectPath("/a except /a");
-        assertEquals(0, o.getSelectionCount());
-        o.selectPath("//* except //b");
-        assertEquals(1, o.getSelectionCount());
-        o.toNextSelection();
-        assertEquals("<a><b>1</b>1</a>", o.xmlText());
+        try (XmlCursor o = XmlObject.Factory.parse("<a><b>1</b>1</a>").newCursor()) {
+            o.selectPath("/a except /a");
+            assertEquals(0, o.getSelectionCount());
+            o.selectPath("//* except //b");
+            assertEquals(1, o.getSelectionCount());
+            o.toNextSelection();
+            assertEquals("<a><b>1</b>1</a>", o.xmlText());
+        }
     }
 
     //If an operand of union, intersect, or except
@@ -143,8 +148,9 @@ public class DeclareNamespaceTest {
 
     @Test(expected = RuntimeException.class)
     public void testSequenceTypeError() throws XmlException {
-        XmlCursor o = XmlObject.Factory.parse("<a/>").newCursor();
-        o.selectPath("(0 to 4) except (0 to 4)");
-        o.toNextSelection();
+        try (XmlCursor o = XmlObject.Factory.parse("<a/>").newCursor()) {
+            o.selectPath("(0 to 4) except (0 to 4)");
+            o.toNextSelection();
+        }
     }
 }

--- a/src/test/java/xmlcursor/xpath/complex/detailed/NodeCopyTest.java
+++ b/src/test/java/xmlcursor/xpath/complex/detailed/NodeCopyTest.java
@@ -35,14 +35,18 @@ public class NodeCopyTest {
         assertEquals( res[0].xmlText(),"<xml-fragment ack:attr=\"val1\" xmlns:ack=\"abc\">foo<b>bar</b></xml-fragment>");
         //"for $e in ./a return <doc>{ $e } </doc>"
         */
-        XmlCursor s1 = s.newCursor().execQuery("./a");
-        assertEquals("<a ack:attr=\"val1\" xmlns:ack=\"abc\">foo<b>bar</b></a>", s1.xmlText());
+        try (XmlCursor c = s.newCursor();
+            XmlCursor s1 = c.execQuery("./a")) {
+            assertEquals("<a ack:attr=\"val1\" xmlns:ack=\"abc\">foo<b>bar</b></a>", s1.xmlText());
+        }
 
         res = s.execQuery("./a");
-        XmlCursor c1 = s.newCursor();
-        c1.toFirstContentToken();
+        XmlObject o;
+        try (XmlCursor c1 = s.newCursor()) {
+            c1.toFirstContentToken();
+            o = c1.getObject();
+        }
 
-        XmlObject o = c1.getObject();
         assertNotSame(o, res[0]);
         assertEquals("<a ack:attr=\"val1\" xmlns:ack=\"abc\">foo<b>bar</b></a>", res[0].xmlText());
     }
@@ -87,23 +91,21 @@ public class NodeCopyTest {
     @Test
     public void testDeleteMe() throws Exception {
         XmlObject t = XmlObject.Factory.parse("<a><b/><b/></a>");
-        XmlCursor cursor =
-            t.newCursor();
-        System.out.println(cursor.getObject());
-        // use xpath to select elements
-        cursor.selectPath("*/*");
+        try (XmlCursor cursor = t.newCursor()) {
+            System.out.println(cursor.getObject());
+            // use xpath to select elements
+            cursor.selectPath("*/*");
 
-        System.out.println("cnt " + cursor.getSelectionCount());
-        // iterate over the selection
-        while (cursor.toNextSelection()) {
-            // two views of the same data:
-            // move back and forth between XmlObject <-> XmlCursor
-            XmlObject trans = cursor.getObject();
+            System.out.println("cnt " + cursor.getSelectionCount());
+            // iterate over the selection
+            while (cursor.toNextSelection()) {
+                // two views of the same data:
+                // move back and forth between XmlObject <-> XmlCursor
+                XmlObject trans = cursor.getObject();
 
-            System.out.println("Trans " + trans.xmlText());
-            System.out.println("xmlText " + cursor.xmlText());
-
+                System.out.println("Trans " + trans.xmlText());
+                System.out.println("xmlText " + cursor.xmlText());
+            }
         }
-
     }
 }

--- a/src/test/java/xmlcursor/xpath/complex/detailed/XPathExpressionTestImpl.java
+++ b/src/test/java/xmlcursor/xpath/complex/detailed/XPathExpressionTestImpl.java
@@ -81,80 +81,85 @@ public class XPathExpressionTestImpl extends XPathExpressionTest {
             "<xml-fragment>Suciu</xml-fragment>",
             "<title>Data on the Web</title>"
             };
-        XmlCursor c = XmlObject.Factory.parse(sXml).newCursor();
-        c.selectPath(query);
-        verifySelection(c, exp);
+        try (XmlCursor c = XmlObject.Factory.parse(sXml).newCursor()) {
+            c.selectPath(query);
+            verifySelection(c, exp);
+        }
     }
 
     @Test
     public void testFor_1() throws Exception {
-        XmlCursor c = XmlObject.Factory.parse("<a/>").newCursor();
-        String query = "for $i in (10, 20),\n" +
-            "    $j in (1, 2)\n" +
-            "return ($i + $j)";
-        c.selectPath(query);
-        String[] expected = new String[] {
-            Common.wrapInXmlFrag("11"),
-            Common.wrapInXmlFrag("12"),
-            Common.wrapInXmlFrag("21"),
-            Common.wrapInXmlFrag("22")
-        };
-        verifySelection(c, expected);
+        try (XmlCursor c = XmlObject.Factory.parse("<a/>").newCursor()) {
+            String query = "for $i in (10, 20),\n" +
+                "    $j in (1, 2)\n" +
+                "return ($i + $j)";
+            c.selectPath(query);
+            String[] expected = new String[] {
+                Common.wrapInXmlFrag("11"),
+                Common.wrapInXmlFrag("12"),
+                Common.wrapInXmlFrag("21"),
+                Common.wrapInXmlFrag("22")
+            };
+            verifySelection(c, expected);
+        }
     }
 
     @Test
     public void testFor_2() throws Exception {
-        XmlCursor c = XmlObject.Factory.parse("<a/>").newCursor();
-        String query = "sum (for $i in (10, 20)" +
-            "return $i)";
-        c.selectPath(query);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("30"), c.xmlText());
+        try (XmlCursor c = XmlObject.Factory.parse("<a/>").newCursor()) {
+            String query = "sum (for $i in (10, 20)" +
+                "return $i)";
+            c.selectPath(query);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("30"), c.xmlText());
+        }
     }
 
     @Test
     public void testIf() throws Exception {
-        XmlCursor c = XmlObject.Factory.parse("<root>" +
-            "<book price='20'>Pooh</book>" +
-            "<cd price='25'>Pooh</cd>" +
-            "<book price='50'>Maid</book>" +
-            "<cd price='25'>Maid</cd>" +
-            "</root>").newCursor();
-        String query = "if (//book[1]/@price) " +
-            "  then //book[1] " +
-            "  else 0";
-        c.selectPath(query);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals("<book price=\"20\">Pooh</book>", c.xmlText());
+        try (XmlCursor c = XmlObject.Factory.parse("<root>" +
+                "<book price='20'>Pooh</book>" +
+                "<cd price='25'>Pooh</cd>" +
+                "<book price='50'>Maid</book>" +
+                "<cd price='25'>Maid</cd>" +
+                "</root>").newCursor()) {
+            String query = "if (//book[1]/@price) " +
+                "  then //book[1] " +
+                "  else 0";
+            c.selectPath(query);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals("<book price=\"20\">Pooh</book>", c.xmlText());
 
-        query = "for $b1 in //book, $b2 in //cd " +
-            "return " +
-            "if ( $b1/@price < $b2/@price )" +
-            " then $b1" +
-            " else $b2";
-        c.selectPath(query);
-        assertEquals(4, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals("<book price=\"20\">Pooh</book>", c.xmlText());
-        c.toNextSelection();
-        assertEquals("<book price=\"20\">Pooh</book>", c.xmlText());
-        c.toNextSelection();
-        assertEquals("<cd price=\"25\">Pooh</cd>", c.xmlText());
-        c.toNextSelection();
-        assertEquals("<cd price=\"25\">Maid</cd>", c.xmlText());
+            query = "for $b1 in //book, $b2 in //cd " +
+                "return " +
+                "if ( $b1/@price < $b2/@price )" +
+                " then $b1" +
+                " else $b2";
+            c.selectPath(query);
+            assertEquals(4, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals("<book price=\"20\">Pooh</book>", c.xmlText());
+            c.toNextSelection();
+            assertEquals("<book price=\"20\">Pooh</book>", c.xmlText());
+            c.toNextSelection();
+            assertEquals("<cd price=\"25\">Pooh</cd>", c.xmlText());
+            c.toNextSelection();
+            assertEquals("<cd price=\"25\">Maid</cd>", c.xmlText());
+        }
     }
 
     @Test
     public void testQuantifiedExpression() throws Exception {
-        XmlCursor c = XmlObject.Factory.parse("<root></root>").newCursor();
-        String query =
-            "some $x in (1, 2, 3), $y in (2, 3, 4) " +
-            "satisfies $x + $y = 4";
-        c.selectPath(query);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals("<xml-fragment>true</xml-fragment>", c.xmlText());
+        try (XmlCursor c = XmlObject.Factory.parse("<root></root>").newCursor()) {
+            String query =
+                "some $x in (1, 2, 3), $y in (2, 3, 4) " +
+                "satisfies $x + $y = 4";
+            c.selectPath(query);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals("<xml-fragment>true</xml-fragment>", c.xmlText());
+        }
     }
 }

--- a/src/test/java/xmlcursor/xpath/complex/detailed/XPathFunctionAuxTest.java
+++ b/src/test/java/xmlcursor/xpath/complex/detailed/XPathFunctionAuxTest.java
@@ -201,45 +201,46 @@ public class XPathFunctionAuxTest extends BasicCursorTestCase {
             "<price at=\"val1\">2</price>" +
             "</bar><bar1>3.00</bar1></foo>";
         m_xc = XmlObject.Factory.parse(sXml).newCursor();
-        XmlCursor _startPos = m_xc.newCursor();
 
-        String sXPath = "boolean(//foo/text())";//"boolean(//foo/text())";
-        m_xc.push();
-        m_xc.selectPath(sXPath);
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("false"),
-            m_xc.xmlText());
-        m_xc.clearSelections();
+        try (XmlCursor _startPos = m_xc.newCursor()) {
+            String sXPath = "boolean(//foo/text())";//"boolean(//foo/text())";
+            m_xc.push();
+            m_xc.selectPath(sXPath);
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("false"),
+                m_xc.xmlText());
+            m_xc.clearSelections();
 
-        //need to reset cursor since it's on a bool outside the doc
-        m_xc.pop();
-        //number
-        m_xc.selectPath("boolean(//price/text())");
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("true"), m_xc.xmlText());
-        m_xc.clearSelections();
+            //need to reset cursor since it's on a bool outside the doc
+            m_xc.pop();
+            //number
+            m_xc.selectPath("boolean(//price/text())");
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("true"), m_xc.xmlText());
+            m_xc.clearSelections();
 
 
-        //number
-        assertTrue(m_xc.toCursor(_startPos));
-        //boolean of Nan is false
-        m_xc.selectPath("boolean(number(name(//price[position()=last()])))");
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
-        m_xc.clearSelections();
+            //number
+            assertTrue(m_xc.toCursor(_startPos));
+            //boolean of Nan is false
+            m_xc.selectPath("boolean(number(name(//price[position()=last()])))");
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
+            m_xc.clearSelections();
 
-        //node-set
-        m_xc.toCursor(_startPos);
-        m_xc.selectPath("boolean(//price)");
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("true"), m_xc.xmlText());
-        m_xc.clearSelections();
+            //node-set
+            m_xc.toCursor(_startPos);
+            m_xc.selectPath("boolean(//price)");
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("true"), m_xc.xmlText());
+            m_xc.clearSelections();
 
-        m_xc.toCursor(_startPos);
-        m_xc.selectPath("boolean(//barK)");
-        m_xc.toNextSelection();
-        assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
-        m_xc.clearSelections();
+            m_xc.toCursor(_startPos);
+            m_xc.selectPath("boolean(//barK)");
+            m_xc.toNextSelection();
+            assertEquals(Common.wrapInXmlFrag("false"), m_xc.xmlText());
+            m_xc.clearSelections();
+        }
     }
 
     @Test

--- a/src/test/java/xmlcursor/xpath/complex/detailed/XPathFunctionAuxTest.java
+++ b/src/test/java/xmlcursor/xpath/complex/detailed/XPathFunctionAuxTest.java
@@ -47,11 +47,11 @@ public class XPathFunctionAuxTest extends BasicCursorTestCase {
         XmlObject[] exXml1 = new XmlObject[]{XmlObject.Factory.parse(ex1R1)};
 
         System.out.println("Test 1: " + ex1Simple);
-        XmlCursor x1 = xDoc.newCursor();
-        x1.selectPath(ex1Simple);
-        XPathCommon.display(x1);
-        XPathCommon.compare(x1, exXml1);
-        x1.dispose();
+        try (XmlCursor x1 = xDoc.newCursor()) {
+            x1.selectPath(ex1Simple);
+            XPathCommon.display(x1);
+            XPathCommon.compare(x1, exXml1);
+        }
     }
 
     @Test

--- a/src/test/java/xmlcursor/xpath/complex/detailed/XPathTest.java
+++ b/src/test/java/xmlcursor/xpath/complex/detailed/XPathTest.java
@@ -204,8 +204,7 @@ public class XPathTest extends BasicCursorTestCase {
     @Test
     public void zvonExample() throws IOException, XmlException {
         XmlObject xDoc = XmlObject.Factory.parse(JarUtil.getResourceFromJar("xbean/xmlcursor/xpath/zvon"+dataset+".xml"));
-        XmlCursor x1 = xDoc.newCursor();
-        try {
+        try (XmlCursor x1 = xDoc.newCursor()) {
             x1.selectPath(xpath);
 
             XmlObject[] exp = new XmlObject[expected.length];
@@ -214,8 +213,6 @@ public class XPathTest extends BasicCursorTestCase {
             }
 
             XPathCommon.compare(x1, exp);
-        } finally {
-            x1.dispose();
         }
     }
 }

--- a/src/test/java/xmlcursor/xpath/xbean_xpath/detailed/AxesTest.java
+++ b/src/test/java/xmlcursor/xpath/xbean_xpath/detailed/AxesTest.java
@@ -56,19 +56,21 @@ public class AxesTest {
         String sExpected =
             "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
             "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        c.selectPath(sQuery1);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
 
-        sQuery1 = "$this/foo/child::bar";
-        c.clearSelections();
-        c.toStartDoc();
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            c.selectPath(sQuery1);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+
+            sQuery1 = "$this/foo/child::bar";
+            c.clearSelections();
+            c.toStartDoc();
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
@@ -77,12 +79,13 @@ public class AxesTest {
         String sExpected =
             "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
             "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
 
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
@@ -91,19 +94,23 @@ public class AxesTest {
         String sExpected =
             "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
             "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     public void testChildAxisDNE() throws XmlException {
         String sQuery1 = "$this/foo/./baz";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        c.selectPath(sQuery1, options);
-        assertEquals(0, c.getSelectionCount());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            c.selectPath(sQuery1, options);
+            assertEquals(0, c.getSelectionCount());
+        }
     }
 
     @Test
@@ -112,15 +119,16 @@ public class AxesTest {
         String sQuery1 = "./descendant::foo";
         String sExpected = "<foo at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
                            "<pre:baz  baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</foo>";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
 
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("foo", c.getName().getLocalPart());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("foo", c.getName().getLocalPart());
 
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
@@ -128,14 +136,15 @@ public class AxesTest {
         String sQuery1 = ".//foo";
         String sExpected = "<foo at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
                            "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</foo>";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
 
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
 
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
@@ -144,236 +153,249 @@ public class AxesTest {
         String sQuery1 = "$this/descendant::foo/.";
         String sExpected = "<foo at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
                            "<pre:baz  baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</foo>";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testDescAxisDNE() throws XmlException {
         String sQuery1 = "$this/descendant::baz";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1, options);
-        assertEquals(0, c.getSelectionCount());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1, options);
+            assertEquals(0, c.getSelectionCount());
+        }
     }
 
     @Test
     public void testChildAttribute() throws XmlException {
         String sExpected = "<xml-fragment at0=\"val0\" xmlns:pre=\"http://uri.com\"/>";
         String sQuery1 = "$this/foo/bar/attribute::at0";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     public void testChildAttributeAbbrev() throws XmlException {
         String sExpected = "<xml-fragment at0=\"val0\" xmlns:pre=\"http://uri.com\"/>";
         String sQuery1 = "$this/foo/bar/@at0";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     public void testDescAttribute() throws XmlException {
         String sExpected = "<xml-fragment at0=\"val0\" xmlns:pre=\"http://uri.com\"/>";
         String sQuery1 = "$this//attribute::at0";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testDescendantOrSelfAxis() throws XmlException {
-
         String sQuery1 = "./descendant-or-self::foo";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        String[] sExpected = {
-            c.xmlText()
-            , "<foo at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
-              "<pre:baz  baz:at0=\"val1\"" +
-              " xmlns:baz=\"http://uri\"/>txt child</foo>"
-        };
 
-
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("foo", c.getName().getLocalPart());
-
-        c.selectPath(sQuery1, options);
-        assertEquals(2, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected[0], c.xmlText());
-        c.toNextSelection();
-        assertEquals(sExpected[1], c.xmlText());
-
-
-    }
-
-    @Test
-    @Ignore
-    public void testDescendantOrSelfAxisDot() throws XmlException {
-        String sQuery1 = "./descendant-or-self::foo";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        String[] sExpected = new String[]
-            {
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            String[] sExpected = {
                 c.xmlText()
                 , "<foo at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
                   "<pre:baz  baz:at0=\"val1\"" +
                   " xmlns:baz=\"http://uri\"/>txt child</foo>"
             };
 
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("foo", c.getName().getLocalPart());
 
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1, options);
+            c.selectPath(sQuery1, options);
+            assertEquals(2, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected[0], c.xmlText());
+            c.toNextSelection();
+            assertEquals(sExpected[1], c.xmlText());
+        }
+    }
 
-        c.selectPath(sQuery1, options);
-        assertEquals(2, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected[0], c.xmlText());
-        c.toNextSelection();
-        assertEquals(sExpected[1], c.xmlText());
+    @Test
+    @Ignore
+    public void testDescendantOrSelfAxisDot() throws XmlException {
+        String sQuery1 = "./descendant-or-self::foo";
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            String[] sExpected = new String[]
+                {
+                    c.xmlText()
+                    , "<foo at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
+                      "<pre:baz  baz:at0=\"val1\"" +
+                      " xmlns:baz=\"http://uri\"/>txt child</foo>"
+                };
+
+
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1, options);
+
+            c.selectPath(sQuery1, options);
+            assertEquals(2, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected[0], c.xmlText());
+            c.toNextSelection();
+            assertEquals(sExpected[1], c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testDescendantOrSelfAxisDNE() throws XmlException {
-
         String sQuery1 = "$this/descendant-or-self::baz";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1, options);
-        assertEquals(0, c.getSelectionCount());
 
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1, options);
+            assertEquals(0, c.getSelectionCount());
+        }
     }
 
     @Test
     @Ignore
     public void testSelfAxis() throws XmlException {
         String sQuery1 = "$this/self::foo";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        String sExpected =
-            c.xmlText();
 
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("foo", c.getName().getLocalPart());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            String sExpected = c.xmlText();
 
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("foo", c.getName().getLocalPart());
+
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     public void testSelfAxisAbbrev() throws XmlException {
         String sQuery1 = ".";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected =
-            c.xmlText();
 
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("foo", c.getName().getLocalPart());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected = c.xmlText();
 
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("foo", c.getName().getLocalPart());
+
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testSelfAxisDot() throws XmlException {
-
         String sQuery1 = "./self::foo";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        String sExpected =
-            c.xmlText();
 
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("foo", c.getName().getLocalPart());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            String sExpected = c.xmlText();
 
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("foo", c.getName().getLocalPart());
+
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testSelfAxisDNE() throws XmlException {
-
         String sQuery1 = "$this/self::baz";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1, options);
-        assertEquals(0, c.getSelectionCount());
 
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1, options);
+            assertEquals(0, c.getSelectionCount());
+        }
     }
 
     @Test
     @Ignore
     public void testNamespaceAxis() throws XmlException {
-
         String sQuery1 = "$this/namespace::http://uri.com";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        String sExpected =
-            c.xmlText();
 
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals(XmlCursor.TokenType.TEXT, c.toNextToken());
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("foo", c.getName().getLocalPart());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            String sExpected = c.xmlText();
 
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals(XmlCursor.TokenType.TEXT, c.toNextToken());
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("foo", c.getName().getLocalPart());
+
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testNamespaceAxisDot() throws XmlException {
-
         String sQuery1 = "./*/namespace::http://uri.com";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        String sExpected =
-            c.xmlText();
 
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("foo", c.getName().getLocalPart());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            String sExpected = c.xmlText();
 
-        c.selectPath(sQuery1, options);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("foo", c.getName().getLocalPart());
+
+            c.selectPath(sQuery1, options);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testNamespaceAxisDNE() throws XmlException {
-
         String sQuery1 = "$this/namespace::*";
-        XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor();
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals(XmlCursor.TokenType.TEXT, c.toNextToken());
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        //to namespace
-        assertEquals(XmlCursor.TokenType.NAMESPACE, c.toNextToken());
-        c.selectPath(sQuery1, options);
-        assertEquals(0, c.getSelectionCount());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlDesc).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals(XmlCursor.TokenType.TEXT, c.toNextToken());
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            //to namespace
+            assertEquals(XmlCursor.TokenType.NAMESPACE, c.toNextToken());
+            c.selectPath(sQuery1, options);
+            assertEquals(0, c.getSelectionCount());
+        }
     }
 }
 

--- a/src/test/java/xmlcursor/xpath/xbean_xpath/detailed/NodeTest.java
+++ b/src/test/java/xmlcursor/xpath/xbean_xpath/detailed/NodeTest.java
@@ -51,71 +51,75 @@ public class NodeTest {
     @Test
     public void testNameTestStar() throws XmlException {
         String sQuery1 = "./*";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected = c.xmlText();
-        c.selectPath(sQuery1);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
 
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected = c.xmlText();
+            c.selectPath(sQuery1);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     public void testNameTestNCName() throws XmlException {
         String sQuery1 = "$this//*";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected = "<pre:baz baz:at0=\"val1\" " +
-                           "xmlns:baz=\"http://uri\" xmlns:pre=\"http://uri.com\"/>";
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.toNextToken();
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("bar", c.getName().getLocalPart());
-        c.selectPath(sQuery1);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
 
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected = "<pre:baz baz:at0=\"val1\" " +
+                               "xmlns:baz=\"http://uri\" xmlns:pre=\"http://uri.com\"/>";
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.toNextToken();
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("bar", c.getName().getLocalPart());
+            c.selectPath(sQuery1);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     public void testNameTestQName_1() throws XmlException {
         String sQuery1 = "declare namespace pre=\"http://uri.com\"; $this//pre:*";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected =
-            "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\" xmlns:pre=\"http://uri.com\"/>";
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        assertEquals("foo", c.getName().getLocalPart());
-        c.selectPath(sQuery1);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
 
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected =
+                "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\" xmlns:pre=\"http://uri.com\"/>";
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            assertEquals("foo", c.getName().getLocalPart());
+            c.selectPath(sQuery1);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     //test a QName that DNE
     @Test
     public void testNameTestQName_2() throws XmlException {
         String sQuery1 = "declare namespace pre=\"http://uri\"; $this//pre:baz";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1);
-        assertEquals(0, c.getSelectionCount());
 
-
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1);
+            assertEquals(0, c.getSelectionCount());
+        }
     }
 
     @Test
     public void testNameTestQName_3() throws XmlException {
         String sQuery1 = "$this//bar";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected = "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
-                           "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
 
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected = "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
+                               "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
@@ -127,13 +131,15 @@ public class NodeTest {
     @Test
     public void testNodeTypeNodeAbbrev() throws XmlException {
         String sQuery1 = "$this/foo/*";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected = "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
-                           "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
-        c.selectPath(sQuery1);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected = "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
+                               "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
+            c.selectPath(sQuery1);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     /**
@@ -143,59 +149,65 @@ public class NodeTest {
     @Ignore
     public void testNodeTypeNode() throws XmlException {
         String sQuery1 = "$this/foo/node()";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected = "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
-                           "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
-        c.selectPath(sQuery1);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected = "<bar at0=\"val0\" xmlns:pre=\"http://uri.com\">" +
+                               "<pre:baz baz:at0=\"val1\" xmlns:baz=\"http://uri\"/>txt child</bar>";
+            c.selectPath(sQuery1);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testNodeTypePI() throws XmlException {
-
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected = "<foo><?xml-stylesheet target=\"http://someuri\"?></foo>";
-        String sQuery = "./foo/processing-instruction()";
-        c.selectPath(sQuery);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected = "<foo><?xml-stylesheet target=\"http://someuri\"?></foo>";
+            String sQuery = "./foo/processing-instruction()";
+            c.selectPath(sQuery);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testNodeTypeText() throws XmlException {
         String sQuery1 = "$this//text()";
-        XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor();
-        String sExpected = " ";
-        assertEquals(XmlCursor.TokenType.START, c.toNextToken());
-        c.selectPath(sQuery1);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlChild).newCursor()) {
+            String sExpected = " ";
+            assertEquals(XmlCursor.TokenType.START, c.toNextToken());
+            c.selectPath(sQuery1);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testPI() throws XmlException {
-        XmlCursor c = XmlObject.Factory.parse(sXmlPI).newCursor();
-        String sExpected = "<?xml-stylesheet target=\"http://someuri\"?>";
-        String sQuery = "./foo/processing-instruction('xml-stylesheet')";
-        c.selectPath(sQuery);
-        assertEquals(1, c.getSelectionCount());
-        c.toNextSelection();
-        assertEquals(sExpected, c.xmlText());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlPI).newCursor()) {
+            String sExpected = "<?xml-stylesheet target=\"http://someuri\"?>";
+            String sQuery = "./foo/processing-instruction('xml-stylesheet')";
+            c.selectPath(sQuery);
+            assertEquals(1, c.getSelectionCount());
+            c.toNextSelection();
+            assertEquals(sExpected, c.xmlText());
+        }
     }
 
     @Test
     @Ignore
     public void testPIDNE() throws XmlException {
-        XmlCursor c = XmlObject.Factory.parse(sXmlPI).newCursor();
-        String sQuery = "./foo/processing-instruction('stylesheet')";
-        c.selectPath(sQuery);
-        assertEquals(0, c.getSelectionCount());
+        try (XmlCursor c = XmlObject.Factory.parse(sXmlPI).newCursor()) {
+            String sQuery = "./foo/processing-instruction('stylesheet')";
+            c.selectPath(sQuery);
+            assertEquals(0, c.getSelectionCount());
+        }
     }
 }

--- a/src/test/java/xmlcursor/xquery/detailed/XQueryTest.java
+++ b/src/test/java/xmlcursor/xquery/detailed/XQueryTest.java
@@ -35,13 +35,14 @@ public class XQueryTest {
         InputStream input = JarUtil.getResourceFromJarasStream("xbean/xmlcursor/XQueryInput.xml");
 
         XmlObject o = XmlObject.Factory.parse(input);
-        XmlCursor c = o.newCursor();
-        XmlCursor c1 = c.execQuery(xq);
-        c1.toFirstContentToken();
-        assertEquals("<employee>\n" +
-                     "\t\t<name>Bob</name>\n" +
-                     "\t\t<ssn>1000</ssn>\n" +
-                     "\t</employee>", c1.xmlText());
+        try (XmlCursor c = o.newCursor();
+            XmlCursor c1 = c.execQuery(xq)) {
+            c1.toFirstContentToken();
+            assertEquals("<employee>\n" +
+                         "\t\t<name>Bob</name>\n" +
+                         "\t\t<ssn>1000</ssn>\n" +
+                         "\t</employee>", c1.xmlText());
+        }
 
         XmlObject[] res = o.execQuery(xq);
         EmpT employeeType = (EmpT) res[0];
@@ -173,15 +174,17 @@ public class XQueryTest {
         String query = "<result>{.},{count(//employee)}</result>";
         String input = "<foo><a><b>text</b>more text</a></foo>";
         XmlObject o = XmlObject.Factory.parse(input);
-        XmlCursor c = o.newCursor();
 
-        XmlObject[] res = o.execQuery("//a");
-        assertEquals("<a><b>text</b>more text</a>", res[0].xmlText());
+        try (XmlCursor c = o.newCursor()) {
+            XmlObject[] res = o.execQuery("//a");
+            assertEquals("<a><b>text</b>more text</a>", res[0].xmlText());
 
-        XmlCursor cur = c.execQuery("//a");
-        // assertEquals(1, cur.getSelectionCount());
-        cur.toFirstContentToken();
-        assertEquals("<a><b>text</b>more text</a>", cur.xmlText());
+            try (XmlCursor cur = c.execQuery("//a")) {
+                // assertEquals(1, cur.getSelectionCount());
+                cur.toFirstContentToken();
+                assertEquals("<a><b>text</b>more text</a>", cur.xmlText());
+            }
+        }
     }
 
     @Test

--- a/src/test/java/xmlcursor/xquery/detailed/XQueryTest.java
+++ b/src/test/java/xmlcursor/xquery/detailed/XQueryTest.java
@@ -62,39 +62,28 @@ public class XQueryTest {
             reslt[1].xmlText());
         assertEquals("<person><name>NotBob</name></person>",
             reslt[2].xmlText());
-        XmlCursor c = o.newCursor();
 
-        //via Cursor
-        /*XmlCursor c1=c.execQuery(query);
-         c1.toFirstContentToken();
-        assertEquals("<person><name>Bob</name></person>",
-                      c1.xmlText() );
-          c1.toNextSibling();
-        assertEquals("<person><name>Beth</name></person>",
-                      c1.xmlText() );
-        c1.dispose();
-        c.dispose();
-        */
-        int i = 0;
-        while (i++ < 2) {
-            //via Cursor--new
-            XmlCursor c1 = c.execQuery(query);
-            //c.dispose();
-            assertEquals(XmlCursor.TokenType.STARTDOC, c1.currentTokenType());
-            assertEquals(XmlCursor.TokenType.START, c1.toNextToken());
-            assertEquals("<person><name>Bob</name></person>",
-                c1.xmlText());
-            // assertTrue(c1.toNextSelection());
-            assertTrue(c1.toNextSibling());
-            assertEquals("<person><name>Beth</name></person>",
-                c1.xmlText());
-            //assertTrue(c1.toNextSelection());
-            assertTrue(c1.toNextSibling());
-            assertEquals("<person><name>NotBob</name></person>",
-                c1.xmlText());
-            c1.dispose();
+        try (XmlCursor c = o.newCursor()) {
+            int i = 0;
+            while (i++ < 2) {
+                //via Cursor--new
+                try (XmlCursor c1 = c.execQuery(query)) {
+                    //c.dispose();
+                    assertEquals(XmlCursor.TokenType.STARTDOC, c1.currentTokenType());
+                    assertEquals(XmlCursor.TokenType.START, c1.toNextToken());
+                    assertEquals("<person><name>Bob</name></person>",
+                        c1.xmlText());
+                    // assertTrue(c1.toNextSelection());
+                    assertTrue(c1.toNextSibling());
+                    assertEquals("<person><name>Beth</name></person>",
+                        c1.xmlText());
+                    //assertTrue(c1.toNextSelection());
+                    assertTrue(c1.toNextSibling());
+                    assertEquals("<person><name>NotBob</name></person>",
+                        c1.xmlText());
+                }
+            }
         }
-        c.dispose();
     }
 
     @Test
@@ -102,34 +91,33 @@ public class XQueryTest {
         String query = JarUtil.getResourceFromJar("xbean/xmlcursor/xquery/Join.xq");
         InputStream input = JarUtil.getResourceFromJarasStream("xbean/xmlcursor/XQueryInput.xml");
         XmlObject o = XmlObject.Factory.parse(input);
-        XmlCursor c = o.newCursor();
-        XmlCursor c1 = c.execQuery(query);
 
-        //  assertEquals(3, c1.getSelectionCount());
-        c1.toFirstContentToken();
-        assertEquals("<result>" +
-                     "<ssn>1000</ssn>,\n" +
-                     "\t\t<name>Bob</name>,\n" +
-                     "\t\t<name>NotBob</name>" +
-                     "</result>",
-            c1.xmlText());
-/*      assertEquals("<xml-fragment>" +
-              "<result>" +
-              "<ssn>1000</ssn>,\n" +
-              "\t\t<name>Bob</name>,\n" +
-              "\t\t<name>NotBob</name>" +
-              "</result>" +
-              "<result><ssn>1001</ssn>,\n" +
-              "\t\t<name>Beth</name>,\n" +
-              "\t\t</result>" +
-              "<result><ssn>1000</ssn>,\n" +
-              "\t\t<name>NotBob</name>,\n" +
-              "\t\t<name>Bob</name>" +
-              "</result>" +
-              "</xml-fragment>",
-                    c1.xmlText() ); */
-        c1.dispose();
-        c.dispose();
+        try (XmlCursor c = o.newCursor();
+            XmlCursor c1 = c.execQuery(query)) {
+            c1.toFirstContentToken();
+            assertEquals("<result>" +
+                         "<ssn>1000</ssn>,\n" +
+                         "\t\t<name>Bob</name>,\n" +
+                         "\t\t<name>NotBob</name>" +
+                         "</result>",
+                c1.xmlText());
+/*          assertEquals("<xml-fragment>" +
+                "<result>" +
+                "<ssn>1000</ssn>,\n" +
+                "\t\t<name>Bob</name>,\n" +
+                "\t\t<name>NotBob</name>" +
+                "</result>" +
+                "<result><ssn>1001</ssn>,\n" +
+                "\t\t<name>Beth</name>,\n" +
+                "\t\t</result>" +
+                "<result><ssn>1000</ssn>,\n" +
+                "\t\t<name>NotBob</name>,\n" +
+                "\t\t<name>Bob</name>" +
+                "</result>" +
+                "</xml-fragment>",
+                        c1.xmlText() ); */
+
+        }
 
         XmlObject[] res = o.execQuery(query);
         assertEquals(3, res.length);
@@ -152,19 +140,18 @@ public class XQueryTest {
         String query = ".//text()";
         InputStream input = JarUtil.getResourceFromJarasStream("xbean/xmlcursor/XQueryInput.xml");
         XmlObject o = XmlObject.Factory.parse(input);
-        XmlCursor c = o.newCursor();
-        XmlCursor c1 = c.execQuery(query);
-           assertEquals(XmlCursor.TokenType.TEXT,c1.toNextToken());
-        //  assertEquals()
-        //assertEquals(19, c1.getSelectionCount());
-        c.dispose();//make sure this doesn't screw things up
-        while (c1.toNextSibling())
-            assertEquals(XmlCursor.TokenType.TEXT, c1.currentTokenType());
-        c1.toStartDoc();
-        assertEquals("<xml-fragment>Bob</xml-fragment>",
-                c1.xmlText());
-        c1.dispose();
-        c.dispose();
+        try (XmlCursor c = o.newCursor();
+            XmlCursor c1 = c.execQuery(query)) {
+            assertEquals(XmlCursor.TokenType.TEXT,c1.toNextToken());
+            //assertEquals(19, c1.getSelectionCount());
+            c.close(); // make sure this doesn't screw things up
+            while (c1.toNextSibling()) {
+                assertEquals(XmlCursor.TokenType.TEXT, c1.currentTokenType());
+            }
+            c1.toStartDoc();
+            assertEquals("<xml-fragment>Bob</xml-fragment>",
+                    c1.xmlText());
+        }
     }
 
     @Test
@@ -173,12 +160,11 @@ public class XQueryTest {
         //String query = "<result>{$this},{count(//employee)}</result>";
         String query = "<result>{.},{count(//employee)}</result>";
         InputStream input = JarUtil.getResourceFromJarasStream("xbean/xmlcursor/XQueryInput.xml");
-        XmlCursor c = XmlObject.Factory.parse(input).newCursor();
-        XmlCursor c1 = c.execQuery(query);
-        assertEquals("",
-            c1.xmlText());
-        c1.dispose();
-        c.dispose();
+        try (XmlCursor c = XmlObject.Factory.parse(input).newCursor();
+            XmlCursor c1 = c.execQuery(query)) {
+            assertEquals("",
+                c1.xmlText());
+        }
     }
 
     @Test
@@ -203,12 +189,11 @@ public class XQueryTest {
     public void testMultiDocJoin() throws XmlException, IOException {
         String query = JarUtil.getResourceFromJar("xbean/xmlcursor/xquery/2DocJoin.xq");
         InputStream input = JarUtil.getResourceFromJarasStream("xbean/xmlcursor/XQueryInput.xml");
-        XmlCursor c = XmlObject.Factory.parse(input).newCursor();
-        XmlCursor c1 = c.execQuery(query);
-        assertEquals("",
-            c1.xmlText());
-        c1.dispose();
-        c.dispose();
+        try (XmlCursor c = XmlObject.Factory.parse(input).newCursor();
+            XmlCursor c1 = c.execQuery(query)) {
+            assertEquals("",
+                c1.xmlText());
+        }
     }
 
     @Test
@@ -261,13 +246,12 @@ public class XQueryTest {
             res[0].xmlText());
         assertEquals("<dept><deptno>5</deptno><headcount>1</headcount><payroll>40</payroll></dept>",
             res[1].xmlText());
-        XmlCursor c = o.newCursor();
-        XmlCursor c1 = c.execQuery(query);
-        c1.toFirstContentToken();
-        assertEquals(res[0].xmlText(),
-            c1.xmlText());
-        c1.dispose();
-        c.dispose();
+        try (XmlCursor c = o.newCursor();
+            XmlCursor c1 = c.execQuery(query)) {
+            c1.toFirstContentToken();
+            assertEquals(res[0].xmlText(),
+                c1.xmlText());
+        }
     }
 
     @Test

--- a/src/test/java/xmlcursor/xquery/detailed/XQueryVariableBindingTest.java
+++ b/src/test/java/xmlcursor/xquery/detailed/XQueryVariableBindingTest.java
@@ -63,30 +63,30 @@ public class XQueryVariableBindingTest extends Common
     /** test the automatic binding of $this to the current node: selectPath() */
     @Test
     public void testThisVariable1() throws Exception {
-        XmlCursor xc = _testDocCursor1();
-        xc.toFirstChild(); //<elem1>
-        xc.toFirstChild(); //<elem11>
-        xc.selectPath("//*[@idRef=$this/@id]");
-        _verifySelection(xc);
-        xc.clearSelections();
-        xc.dispose();
+        try (XmlCursor xc = _testDocCursor1()) {
+            xc.toFirstChild(); //<elem1>
+            xc.toFirstChild(); //<elem11>
+            xc.selectPath("//*[@idRef=$this/@id]");
+            _verifySelection(xc);
+            xc.clearSelections();
+        }
     }
 
     // this fails: see JIRA issue XMLBEANS-276
     /** test the binding of a variable to the current node: selectPath() */
     @Test
     public void testCurrentNodeVariable1() throws Exception {
-        XmlCursor xc = _testDocCursor1();
-        xc.toFirstChild();
-        xc.toFirstChild();
-        XmlOptions opts = new XmlOptions();
-        opts.setXqueryCurrentNodeVar("cur");
-        //String varDecl = "declare variable $cur external; ";
-        //xc.selectPath(varDecl + "//*[@idRef=$cur/@id]", opts);
-        xc.selectPath("//*[@idRef=$cur/@id]", opts);
-        _verifySelection(xc);
-        xc.clearSelections();
-        xc.dispose();
+        try (XmlCursor xc = _testDocCursor1()) {
+            xc.toFirstChild();
+            xc.toFirstChild();
+            XmlOptions opts = new XmlOptions();
+            opts.setXqueryCurrentNodeVar("cur");
+            //String varDecl = "declare variable $cur external; ";
+            //xc.selectPath(varDecl + "//*[@idRef=$cur/@id]", opts);
+            xc.selectPath("//*[@idRef=$cur/@id]", opts);
+            _verifySelection(xc);
+            xc.clearSelections();
+        }
     }
 
     private XmlCursor _testDocCursor2() throws Exception {
@@ -108,24 +108,20 @@ public class XQueryVariableBindingTest extends Common
     @Test
     public void testThisVariable2() throws Exception
     {
-        XmlCursor xc = _testDocCursor2();
-        // xc.toNextToken();
         String q =
             "for $e in $this/employees/employee " +
             "let $s := $e/address/state " +
             "where $s = 'WA' " +
             "return $e//phone[@location='work']";
-        XmlCursor qc = xc.execQuery(q);
-        _verifyQueryResult(qc);
-        xc.dispose();
-        qc.dispose();
+        try (XmlCursor xc = _testDocCursor2();
+            XmlCursor qc = xc.execQuery(q)) {
+            _verifyQueryResult(qc);
+        }
     }
 
     /** test the binding of a variable to the current node: execQuery() */
     @Test
     public void testCurrentNodeVariable2() throws Exception {
-        XmlCursor xc = _testDocCursor2();
-        // xc.toNextToken();
         String q =
             "for $e in $cur/employees/employee " +
             "let $s := $e/address/state " +
@@ -133,12 +129,10 @@ public class XQueryVariableBindingTest extends Common
             "return $e//phone[@location='work']";
         XmlOptions opts = new XmlOptions();
         opts.setXqueryCurrentNodeVar("cur");
-        //String varDecl = "declare variable $cur external; ";
-        //XmlCursor qc = xc.execQuery(varDecl + q, opts);
-        XmlCursor qc = xc.execQuery(q, opts);
-        _verifyQueryResult(qc);
-        xc.dispose();
-        qc.dispose();
+        try (XmlCursor xc = _testDocCursor2();
+            XmlCursor qc = xc.execQuery(q, opts)) {
+            _verifyQueryResult(qc);
+        }
     }
 
     private XmlObject[] _execute(XmlObject xo, Map m, String q) {

--- a/src/test/java/xmlobject/checkin/AssortedTests.java
+++ b/src/test/java/xmlobject/checkin/AssortedTests.java
@@ -157,12 +157,12 @@ public class AssortedTests {
         xobj = xcur.getObject();
         String result = xobj.toString();
         System.out.println(result);
-        
+
         xcur.toFirstChild();
         xcur.toFirstChild();
         xcur.toFirstContentToken();
         xcur.insertChars("<html><body>this is a test</body></html>");
-        
+
         System.out.println(xobj);
         */
     }

--- a/src/test/java/xmlobject/checkin/AssortedTests.java
+++ b/src/test/java/xmlobject/checkin/AssortedTests.java
@@ -36,20 +36,21 @@ public class AssortedTests {
     @Test
     public void testSaverCharEscaping() throws XmlException {
         XmlObject xdoc = XmlObject.Factory.parse("<test>something</test>");
-        XmlCursor cur = xdoc.newCursor();
-        cur.toFirstChild();
-        // valid chars
-        cur.setTextValue("<something or other:\u03C0\uD7FF>");
-        assertEquals("<test>&lt;something or other:\u03C0\uD7FF></test>", xdoc.toString());
+        try (XmlCursor cur = xdoc.newCursor()) {
+            cur.toFirstChild();
+            // valid chars
+            cur.setTextValue("<something or other:\u03C0\uD7FF>");
+            assertEquals("<test>&lt;something or other:\u03C0\uD7FF></test>", xdoc.toString());
 
-        // invalid chars - control chars, FFFF/FFFE, etc
-        cur.setTextValue("<something\0or\1other:\u0045\u001F>");
-        assertEquals("<test>&lt;something?or?other:\u0045?></test>", xdoc.toString());
+            // invalid chars - control chars, FFFF/FFFE, etc
+            cur.setTextValue("<something\0or\1other:\u0045\u001F>");
+            assertEquals("<test>&lt;something?or?other:\u0045?></test>", xdoc.toString());
 
-        String greekChars = "\uD835\uDF4A\uD835\uDF4B\uD835\uDF4C\uD835\uDF4D\uD835\uDF4E\uD835\uDF4F\uD835\uDF50\uD835"
-                            + "\uDF51\uD835\uDF52\uD835\uDF53\uD835\uDF54\uD835\uDF55";
-        cur.setTextValue(greekChars);
-        assertEquals("<test>" + greekChars + "</test>", xdoc.toString());
+            String greekChars = "\uD835\uDF4A\uD835\uDF4B\uD835\uDF4C\uD835\uDF4D\uD835\uDF4E\uD835\uDF4F\uD835\uDF50\uD835"
+                                + "\uDF51\uD835\uDF52\uD835\uDF53\uD835\uDF54\uD835\uDF55";
+            cur.setTextValue(greekChars);
+            assertEquals("<test>" + greekChars + "</test>", xdoc.toString());
+        }
     }
 
     // bug 26140/26104
@@ -186,6 +187,7 @@ public class AssortedTests {
         int i = 0;
         try {
             for (i = 0; i < 2000 * 1000; i++) {
+                // Cursor not closed intentionally
                 XmlCursor cur = obj.newCursor();
                 // cur.dispose(); skipping this depends on finalization or else OOM
             }

--- a/src/test/java/xmlobject/checkin/InstanceValidationTests.java
+++ b/src/test/java/xmlobject/checkin/InstanceValidationTests.java
@@ -1872,10 +1872,10 @@ public class InstanceValidationTests {
                 stl.parse((String) validInstances[i], null, options);
 
             if (!startOnDocument) {
-                XmlCursor c = x.newCursor();
-                c.toFirstChild();
-                x = c.getObject();
-                c.dispose();
+                try (XmlCursor c = x.newCursor()) {
+                    c.toFirstChild();
+                    x = c.getObject();
+                }
             }
 
             List<XmlError> xel = new ArrayList<>();
@@ -1905,10 +1905,10 @@ public class InstanceValidationTests {
                 x = stl.parse((String) invalidInstances[i], null, options);
 
                 if (!startOnDocument) {
-                    XmlCursor c = x.newCursor();
-                    c.toFirstChild();
-                    x = c.getObject();
-                    c.dispose();
+                    try (XmlCursor c = x.newCursor()) {
+                        c.toFirstChild();
+                        x = c.getObject();
+                    }
                 }
 
                 boolean isValid = x.validate();

--- a/src/test/java/xmlobject/checkin/InstanceValidationTests.java
+++ b/src/test/java/xmlobject/checkin/InstanceValidationTests.java
@@ -1205,16 +1205,16 @@ public class InstanceValidationTests {
                 "<hee yee='3'><haw>66</haw></hee>",
                 null, null);
 
-        XmlCursor c = x.newCursor();
+        try (XmlCursor c = x.newCursor()) {
+            do {
+                XmlObject obj = c.getObject();
 
-        do {
-            XmlObject obj = c.getObject();
+                if (obj != null) {
+                    obj.validate();
+                }
 
-            if (obj != null) {
-                obj.validate();
-            }
-
-        } while (!c.toNextToken().isNone());
+            } while (!c.toNextToken().isNone());
+        }
 
         // invalid
 
@@ -1225,26 +1225,27 @@ public class InstanceValidationTests {
 
         assertTrue(!x.validate());
 
-        c = x.newCursor();
-        c.toNextToken();
-        c.toNextToken();
+        try (XmlCursor c = x.newCursor()) {
+            c.toNextToken();
+            c.toNextToken();
 
-        assertTrue(!c.getObject().validate());
+            assertTrue(!c.getObject().validate());
+        }
 
         // No schema
 
         x = XmlObject.Factory.parse("<foo x='y'>asas<bar>asas</bar></foo>");
 
-        c = x.newCursor();
+        try (XmlCursor c = x.newCursor()) {
+            do {
+                XmlObject obj = c.getObject();
 
-        do {
-            XmlObject obj = c.getObject();
+                if (obj != null) {
+                    obj.validate();
+                }
 
-            if (obj != null) {
-                obj.validate();
-            }
-
-        } while (!c.toNextToken().isNone());
+            } while (!c.toNextToken().isNone());
+        }
     }
 
     @Test(expected = XmlException.class)
@@ -1299,28 +1300,28 @@ public class InstanceValidationTests {
 
         assertTrue(x.validate());
 
-        XmlCursor c = x.newCursor();
+        try (XmlCursor c = x.newCursor()) {
+            c.toFirstChild();
 
-        c.toFirstChild();
+            XmlObject base = c.getObject();
 
-        XmlObject base = c.getObject();
+            c.toEndToken();
+            c.insertElement("bar");
 
-        c.toEndToken();
-        c.insertElement("bar");
+            assertTrue(!x.validate());
 
-        assertTrue(!x.validate());
+            c.toPrevSibling();
 
-        c.toPrevSibling();
+            c.removeXml();
 
-        c.removeXml();
+            assertTrue(x.validate());
 
-        assertTrue(x.validate());
+            base.changeType(stl.findType(new QName("derived")));
 
-        base.changeType(stl.findType(new QName("derived")));
+            c.insertElement("bar");
 
-        c.insertElement("bar");
-
-        assertTrue(x.validate());
+            assertTrue(x.validate());
+        }
     }
 
     // Tests abstract & block attributes on ComplexType

--- a/src/test/java/xmlobject/checkin/XPathTest.java
+++ b/src/test/java/xmlobject/checkin/XPathTest.java
@@ -34,21 +34,20 @@ public class XPathTest {
                 "</b>" +
                 "<c>val3</c>" +
                 "</a>");
-        final XmlCursor c = obj.newCursor();
+        try (XmlCursor c = obj.newCursor()) {
+            c.selectPath(".//b/c");
 
-        c.selectPath(".//b/c");
+            int selCount = c.getSelectionCount();
+            assertEquals("SelectionCount", 1, selCount);
 
-        int selCount = c.getSelectionCount();
-        assertEquals("SelectionCount", 1, selCount);
+            while (c.hasNextSelection()) {
+                c.toNextSelection();
 
-        while (c.hasNextSelection()) {
-            c.toNextSelection();
-
-            assertTrue("OnStartElement", c.isStart());
-            assertEquals("TextValue", "val1", c.getTextValue());
-            System.out.println(" -> " + c.getObject());
+                assertTrue("OnStartElement", c.isStart());
+                assertEquals("TextValue", "val1", c.getTextValue());
+                System.out.println(" -> " + c.getObject());
+            }
         }
-        c.dispose();
     }
 
     @Test
@@ -64,29 +63,27 @@ public class XPathTest {
                 "</b>" +
                 "<c>val4</c>" +
                 "</a>");
-        final XmlCursor c = obj.newCursor();
+        try (XmlCursor c = obj.newCursor()) {
+            c.selectPath(".//b/c");
 
-        c.selectPath(".//b/c");
+            int selCount = c.getSelectionCount();
+            assertEquals("SelectionCount", 2, selCount);
 
-        int selCount = c.getSelectionCount();
-        assertEquals("SelectionCount", 2, selCount);
+            assertTrue("hasNextSelection", c.hasNextSelection());
+            c.toNextSelection();
 
-        assertTrue("hasNextSelection", c.hasNextSelection());
-        c.toNextSelection();
-
-        System.out.println(" -> " + c.getObject());
-        assertTrue("OnStartElement", c.isStart());
-        assertEquals("TextValue", "val1", c.getTextValue());
+            System.out.println(" -> " + c.getObject());
+            assertTrue("OnStartElement", c.isStart());
+            assertEquals("TextValue", "val1", c.getTextValue());
 
 
-        assertTrue("hasNextSelection2", c.hasNextSelection());
-        c.toNextSelection();
+            assertTrue("hasNextSelection2", c.hasNextSelection());
+            c.toNextSelection();
 
-        System.out.println(" -> " + c.getObject());
-        assertTrue("OnStartElement2", c.isStart());
-        assertEquals("TextValue2", "val3", c.getTextValue());
-
-        c.dispose();
+            System.out.println(" -> " + c.getObject());
+            assertTrue("OnStartElement2", c.isStart());
+            assertEquals("TextValue2", "val3", c.getTextValue());
+        }
     }
 
     @Test
@@ -106,20 +103,20 @@ public class XPathTest {
                 "</b>" +
                 "<c>val4</c>" +
                 "</a>");
-        final XmlCursor c = obj.newCursor();
 
-        c.selectPath(".//b/c//c");
+        try (XmlCursor c = obj.newCursor()) {
+            c.selectPath(".//b/c//c");
 
-        int selCount = c.getSelectionCount();
-        assertEquals("SelectionCount", 1, selCount);
+            int selCount = c.getSelectionCount();
+            assertEquals("SelectionCount", 1, selCount);
 
-        while (c.hasNextSelection()) {
-            c.toNextSelection();
+            while (c.hasNextSelection()) {
+                c.toNextSelection();
 
-            System.out.println(" -> " + c.getObject());
-            assertTrue("OnStartElement", c.isStart());
-            assertEquals("TextValue", "val5", c.getTextValue());
+                System.out.println(" -> " + c.getObject());
+                assertTrue("OnStartElement", c.isStart());
+                assertEquals("TextValue", "val5", c.getTextValue());
+            }
         }
-        c.dispose();
     }
 }

--- a/src/test/java/xmlobject/common/StringXmlReader.java
+++ b/src/test/java/xmlobject/common/StringXmlReader.java
@@ -58,9 +58,8 @@ public class StringXmlReader implements Runnable {
             return;
         }
 
-        try {
+        try (XmlCursor cur = x.newCursor()) {
             // Walk through the XML
-            XmlCursor cur = x.newCursor();
             cur.toStartDoc();
             do {
                 // Sleep for 10 milliseconds
@@ -73,7 +72,6 @@ public class StringXmlReader implements Runnable {
                 //System.out.println("["+tName+"]: " + cur.currentTokenType().toString());
                 cur.toNextToken();
             } while (cur.hasNextToken());
-            cur.dispose();
         } catch (Exception e) {
             System.out.println("Exception in thread " + tName);
             e.printStackTrace();

--- a/src/test/java/xmlobject/detailed/CompareToTest.java
+++ b/src/test/java/xmlobject/detailed/CompareToTest.java
@@ -96,10 +96,11 @@ public class CompareToTest {
     public void testCompareValue() throws Exception {
         m_xo = XmlObject.Factory.parse(
             JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
-        XmlCursor m_xc = m_xo.newCursor();
-        m_xc.toFirstChild();
-        XmlObject xo = m_xc.getObject();
-        assertEquals(XmlObject.NOT_EQUAL, m_xo.compareValue(xo));
+        try (XmlCursor m_xc = m_xo.newCursor()) {
+            m_xc.toFirstChild();
+            XmlObject xo = m_xc.getObject();
+            assertEquals(XmlObject.NOT_EQUAL, m_xo.compareValue(xo));
+        }
     }
 
     private XmlObject m_xo;

--- a/src/test/java/xmlobject/detailed/SetIdentityTest.java
+++ b/src/test/java/xmlobject/detailed/SetIdentityTest.java
@@ -36,12 +36,13 @@ public class SetIdentityTest {
         CarLocationMessageDocument clm =
                 (CarLocationMessageDocument) XmlObject.Factory.parse(
                         JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
-        XmlCursor xc = clm.newCursor();
 
-        xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT + "$this//GeographicLocation");
-        xc.toNextSelection();
-        GeographicLocation gl = (GeographicLocation) xc.getObject();
-        xc.dispose();
+        GeographicLocation gl;
+        try (XmlCursor xc = clm.newCursor()) {
+            xc.selectPath(Common.CLM_NS_XQUERY_DEFAULT + "$this//GeographicLocation");
+            xc.toNextSelection();
+            gl = (GeographicLocation) xc.getObject();
+        }
         LocationIdentifier li = gl.addNewLocationIdentifier();
         li.setQualifier(CodeList309.FR);
         CodeList309 cl309 = li.xgetQualifier();
@@ -49,7 +50,6 @@ public class SetIdentityTest {
         li.xsetQualifier(cl309);
         gl.setLocationIdentifier(li);
         assertEquals(CodeList309.FR, gl.getLocationIdentifier().getQualifier());
-
     }
 
 }

--- a/src/test/java/xmlobject/detailed/TypedObjectCursor.java
+++ b/src/test/java/xmlobject/detailed/TypedObjectCursor.java
@@ -26,23 +26,24 @@ public class TypedObjectCursor {
     @Test
     public void testObjectCursor() {
         XmlPurchaseOrderDocumentBean.PurchaseOrder po = XmlPurchaseOrderDocumentBean.PurchaseOrder.Factory.newInstance();
-        XmlCursor cur = po.newCursor();
-        XmlCustomerBean cust = po.addNewCustomer();
-        cust.setAddress("123 Fake Street");
-        cust.setAge(23);
-        cust.setName("Lisa Simpson");
-        cur.toFirstContentToken();
-        assertEquals(XmlCursor.TokenType.START, cur.currentTokenType());
-        assertEquals(XmlCursor.TokenType.ATTR, cur.toNextToken());
-        assertEquals("<xml-fragment age=\"23\"/>", cur.xmlText());
-        assertEquals(XmlCursor.TokenType.START, cur.toNextToken());
-        assertEquals(XmlCursor.TokenType.TEXT, cur.toNextToken());
-        assertEquals("<xml-fragment>Lisa Simpson</xml-fragment>", cur.xmlText());
-        assertEquals(XmlCursor.TokenType.END, cur.toNextToken());
-        assertEquals(XmlCursor.TokenType.START, cur.toNextToken());
-        assertEquals(XmlCursor.TokenType.TEXT, cur.toNextToken());
-        assertEquals("<xml-fragment>123 Fake Street</xml-fragment>", cur.xmlText());
-        cur.toPrevToken();
-        cur.setTextValue("456".toCharArray(), 0, 3);
+        try (XmlCursor cur = po.newCursor()) {
+            XmlCustomerBean cust = po.addNewCustomer();
+            cust.setAddress("123 Fake Street");
+            cust.setAge(23);
+            cust.setName("Lisa Simpson");
+            cur.toFirstContentToken();
+            assertEquals(XmlCursor.TokenType.START, cur.currentTokenType());
+            assertEquals(XmlCursor.TokenType.ATTR, cur.toNextToken());
+            assertEquals("<xml-fragment age=\"23\"/>", cur.xmlText());
+            assertEquals(XmlCursor.TokenType.START, cur.toNextToken());
+            assertEquals(XmlCursor.TokenType.TEXT, cur.toNextToken());
+            assertEquals("<xml-fragment>Lisa Simpson</xml-fragment>", cur.xmlText());
+            assertEquals(XmlCursor.TokenType.END, cur.toNextToken());
+            assertEquals(XmlCursor.TokenType.START, cur.toNextToken());
+            assertEquals(XmlCursor.TokenType.TEXT, cur.toNextToken());
+            assertEquals("<xml-fragment>123 Fake Street</xml-fragment>", cur.xmlText());
+            cur.toPrevToken();
+            cur.setTextValue("456".toCharArray(), 0, 3);
+        }
     }
 }

--- a/src/test/java/xmlobject/detailed/TypedSettersTests.java
+++ b/src/test/java/xmlobject/detailed/TypedSettersTests.java
@@ -83,13 +83,14 @@ public class TypedSettersTests {
         throws Exception {
         XmlObject x = XmlObject.Factory.parse("<xyzzy/>");
         XmlObject x2 = XmlObject.Factory.parse("<bubba>moo</bubba>");
-        XmlCursor c = x.newCursor();
-        XmlCursor c2 = x2.newCursor();
 
-        c.toNextToken();
-        c2.toNextToken();
+        try (XmlCursor c = x.newCursor();
+            XmlCursor c2 = x2.newCursor()) {
+            c.toNextToken();
+            c2.toNextToken();
 
-        c.getObject().set(c2.getObject());
+            c.getObject().set(c2.getObject());
+        }
 
         assertEquals("<xyzzy>moo</xyzzy>", x.xmlText());
     }
@@ -99,15 +100,16 @@ public class TypedSettersTests {
         throws Exception {
         XmlObject x = XmlObject.Factory.parse("<xyzzy a=''/>");
         XmlObject x2 = XmlObject.Factory.parse("<bubba b='moo'/>");
-        XmlCursor c = x.newCursor();
-        XmlCursor c2 = x2.newCursor();
 
-        c.toNextToken();
-        c.toNextToken();
-        c2.toNextToken();
-        c2.toNextToken();
+        try (XmlCursor c = x.newCursor();
+            XmlCursor c2 = x2.newCursor()) {
+            c.toNextToken();
+            c.toNextToken();
+            c2.toNextToken();
+            c2.toNextToken();
 
-        c.getObject().set(c2.getObject());
+            c.getObject().set(c2.getObject());
+        }
 
         assertEquals("<xyzzy a=\"moo\"/>", x.xmlText());
     }

--- a/src/test/java/xmlobject/schematypes/checkin/QNameTests.java
+++ b/src/test/java/xmlobject/schematypes/checkin/QNameTests.java
@@ -53,22 +53,24 @@ public class QNameTests {
                 "<any " + ns + " xsi:type='xs:QName' xmlns:xxx='xxx.com'>" +
                     "xxx:abc</any>", null, null);
 
-        XmlCursor sourceCursor = sourceDocument.newCursor();
+        XmlQName sourceQName;
+        try (XmlCursor sourceCursor = sourceDocument.newCursor()) {
+            sourceCursor.toFirstChild();
 
-        sourceCursor.toFirstChild();
-
-        XmlQName sourceQName = (XmlQName) sourceCursor.getObject();
+            sourceQName = (XmlQName) sourceCursor.getObject();
+        }
 
         XmlObject targetDocument =
             stl.parse(
                 "<any " + ns + " xsi:type='xs:QName'>" +
                     "</any>", null, null);
 
-        XmlCursor targetCursor = targetDocument.newCursor();
+        XmlQName targetQName;
+        try (XmlCursor targetCursor = targetDocument.newCursor()) {
+            targetCursor.toFirstChild();
 
-        targetCursor.toFirstChild();
-
-        XmlQName targetQName = (XmlQName) targetCursor.getObject();
+            targetQName = (XmlQName) targetCursor.getObject();
+        }
 
         targetQName.set(sourceQName);
 
@@ -83,13 +85,11 @@ public class QNameTests {
                 "<any " + ns + " xsi:type='xs:QName' xmlns:xxx='xxx.com'>" +
                     "</any>", null, null);
 
-        targetCursor = targetDocument.newCursor();
+        try (XmlCursor targetCursor = targetDocument.newCursor()) {
+            targetCursor.toFirstChild();
 
-        targetCursor.toFirstChild();
+            targetQName = (XmlQName) targetCursor.getObject();
 
-        targetQName = (XmlQName) targetCursor.getObject();
-
-        try {
             targetQName.setStringValue("zzz:abc");
             fail("Must fail");
         } catch (Throwable t) {

--- a/src/test/java/xmlobject/schematypes/checkin/SchemaTypesTests.java
+++ b/src/test/java/xmlobject/schematypes/checkin/SchemaTypesTests.java
@@ -155,32 +155,36 @@ public class SchemaTypesTests {
         Person person = doc.getCustomer();
 
         XmlObject xmlobj;
-        XmlCursor xmlcurs;
 
         person.setFirstname("George");
         xmlobj = person.xgetFirstname();
-        xmlcurs = xmlobj.newCursor();
-        assertEquals("George", xmlcurs.getTextValue() );
+        try (XmlCursor xmlcurs = xmlobj.newCursor()) {
+            assertEquals("George", xmlcurs.getTextValue() );
+        }
 
         person.setQnameAtt( new QName("http://ggg.com","hhh") );
         xmlobj = person.xgetQnameAtt();
-        xmlcurs = xmlobj.newCursor();
-        assertEquals("ggg:hhh", xmlcurs.getTextValue() );
+        try (XmlCursor xmlcurs = xmlobj.newCursor()) {
+            assertEquals("ggg:hhh", xmlcurs.getTextValue() );
+        }
 
         person.setQname( new QName("http://ggg.com/gggAgain","kkk") );
         xmlobj = person.xgetQname();
-        xmlcurs = xmlobj.newCursor();
-        assertEquals("ggg1:kkk", xmlcurs.getTextValue() );
+        try (XmlCursor xmlcurs = xmlobj.newCursor()) {
+            assertEquals("ggg1:kkk", xmlcurs.getTextValue() );
+        }
 
         person.setAnyuri( "crossgain.com" );
         xmlobj = person.xgetAnyuri();
-        xmlcurs = xmlobj.newCursor();
-        assertEquals("crossgain.com", xmlcurs.getTextValue() );
+        try (XmlCursor xmlcurs = xmlobj.newCursor()) {
+            assertEquals("crossgain.com", xmlcurs.getTextValue() );
+        }
 
         person.setAnyuriAtt( "www.crossgain.com" );
         xmlobj = person.xgetAnyuriAtt();
-        xmlcurs = xmlobj.newCursor();
-        assertEquals("www.crossgain.com", xmlcurs.getTextValue() );
+        try (XmlCursor xmlcurs = xmlobj.newCursor()) {
+            assertEquals("www.crossgain.com", xmlcurs.getTextValue() );
+        }
 
         //person.setNotation("GIF");
         //xmlobj = person.getNotation();

--- a/src/test/java/xmlobject/xmlloader/detailed/XmlStreamBeanReader.java
+++ b/src/test/java/xmlobject/xmlloader/detailed/XmlStreamBeanReader.java
@@ -66,11 +66,12 @@ public class XmlStreamBeanReader {
     @Test
     public void testXmlStreamReaderException() throws XMLStreamException {
         XmlObject xo = XmlObject.Factory.newInstance();
-        XmlCursor xc = xo.newCursor();
-        xc.toNextToken();
+        try (XmlCursor xc = xo.newCursor()) {
+            xc.toNextToken();
 
-        xc.insertElementWithText("int", "http://openuri.org/testNumerals", "5");
-        xc.insertElementWithText("float", "http://openuri.org/testNumerals", "7.654321");
+            xc.insertElementWithText("int", "http://openuri.org/testNumerals", "5");
+            xc.insertElementWithText("float", "http://openuri.org/testNumerals", "7.654321");
+        }
 
         XMLStreamReader xsr = xo.newXMLStreamReader();
 

--- a/src/test/java/xmltokensource/detailed/NewDomNodeTest.java
+++ b/src/test/java/xmltokensource/detailed/NewDomNodeTest.java
@@ -112,11 +112,8 @@ public class NewDomNodeTest extends BasicCursorTestCase {
         assertNotNull(doc);
         XmlObject xo = XmlObject.Factory.parse(doc);
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = xo.newCursor();
-        try {
+        try (XmlCursor xc1 = xo.newCursor()) {
             compareDocTokens(m_xc, xc1);
-        } finally {
-            xc1.dispose();
         }
     }
 }

--- a/src/test/java/xmltokensource/detailed/PrettyPrintNamespaceTest.java
+++ b/src/test/java/xmltokensource/detailed/PrettyPrintNamespaceTest.java
@@ -30,12 +30,13 @@ public class PrettyPrintNamespaceTest {
     public void testWithNewInstance()
             throws Exception {
         XmlObject x = XmlObject.Factory.newInstance();
-        XmlCursor c = x.newCursor();
 
-        c.toNextToken();
-        c.beginElement("a", "aaaa");
-        c.insertAttribute("a", "aaaa");
-        c.insertNamespace("", "aaaa");
+        try (XmlCursor c = x.newCursor()) {
+            c.toNextToken();
+            c.beginElement("a", "aaaa");
+            c.insertAttribute("a", "aaaa");
+            c.insertNamespace("", "aaaa");
+        }
 
         String str =
                 "<a aaaa:a=\"\" xmlns=\"aaaa\" xmlns:aaaa=\"aaaa\"/>";

--- a/src/test/java/xmltokensource/detailed/RoundTripLoaderTest.java
+++ b/src/test/java/xmltokensource/detailed/RoundTripLoaderTest.java
@@ -47,11 +47,8 @@ public class RoundTripLoaderTest extends BasicCursorTestCase {
         assertNotNull(doc);
         XmlObject xo = XmlObject.Factory.parse(doc, map);
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = xo.newCursor();
-        try {
+        try (XmlCursor xc1 = xo.newCursor()) {
             compareDocTokens(m_xc, xc1);
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -72,11 +69,8 @@ public class RoundTripLoaderTest extends BasicCursorTestCase {
         XmlOptions options = new XmlOptions(map);
         XmlObject xo = XmlObject.Factory.parse(is, options);
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = xo.newCursor();
-        try {
+        try (XmlCursor xc1 = xo.newCursor()) {
             compareDocTokens(m_xc, xc1);
-        } finally {
-            xc1.dispose();
         }
     }
 
@@ -112,11 +106,8 @@ public class RoundTripLoaderTest extends BasicCursorTestCase {
         XmlOptions options = new XmlOptions(map);
         XmlObject xo = XmlObject.Factory.parse(sXml, options);
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = xo.newCursor();
-        try {
+        try (XmlCursor xc1 = xo.newCursor()) {
             compareDocTokens(m_xc, xc1);
-        } finally {
-            xc1.dispose();
         }
     }
 

--- a/src/test/java/xmltokensource/detailed/RoundTripLoaderTest.java
+++ b/src/test/java/xmltokensource/detailed/RoundTripLoaderTest.java
@@ -26,7 +26,6 @@ import xmlcursor.common.BasicCursorTestCase;
 import xmlcursor.common.Common;
 
 import java.io.InputStream;
-import java.io.Reader;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -82,21 +81,6 @@ public class RoundTripLoaderTest extends BasicCursorTestCase {
     @Test
     public void testNewInputStreamWithOptionsRoundTrip() throws Exception {
         _newInputStreamRoundTrip(m_map);
-    }
-
-    private void _newReaderRoundTrip(XmlOptions map) throws Exception {
-        m_xo = XmlObject.Factory.parse(Common.XML_FOO_BAR_NESTED_SIBLINGS);
-        Reader reader = m_xo.newReader(map);
-        assertNotNull(reader);
-        XmlOptions options = new XmlOptions(map);
-        XmlObject xo = XmlObject.Factory.parse(reader, options);
-        m_xc = m_xo.newCursor();
-        XmlCursor xc1 = xo.newCursor();
-        try {
-            compareDocTokens(m_xc, xc1);
-        } finally {
-            xc1.dispose();
-        }
     }
 
     private void _xmlTextRoundTrip(XmlOptions map) throws Exception {

--- a/src/test/java/xmltokensource/detailed/XmlTextTest.java
+++ b/src/test/java/xmltokensource/detailed/XmlTextTest.java
@@ -104,12 +104,9 @@ public class XmlTextTest extends BasicCursorTestCase {
         m_xo = XmlObject.Factory.parse(
             JarUtil.getResourceFromJar(Common.TRANXML_FILE_CLM));
         m_xc = m_xo.newCursor();
-        XmlCursor xc1 = m_xo.newCursor();
-        xc1.toFirstChild();
-        try {
+        try (XmlCursor xc1 = m_xo.newCursor()) {
+            xc1.toFirstChild();
             assertEquals(m_xc.xmlText().replaceFirst("(?s)<!--.*-->", ""), xc1.xmlText());
-        } finally {
-            xc1.dispose();
         }
     }
 


### PR DESCRIPTION
This changes contain multiple commits, maybe some of them could be discarded.

Only the first one is important, the other ones are to remove the usage of the new deprecated method and use try-with resources where appropriate.

The other two WIP titled commits are to ask for advice, it have comments about how the API isn't good for an `AutoCloseable XmlCursor` and noticing that `XmlError` embedded cursors are never disposed. I avoided closing the cursors that are being added to a `XmlError`, but I think maybe the best solution is for `XmlError` to do defensive copies of the cursor and then the code that creates errors must close its cursors.

Thanks to this interface changes, some of the runtime code (the tests contains the majority of the changes) now properly closes some cursors that were being leaked.

The last patch includes simple formatting changes made by the editor while changing these files, only removing end on line spaces because the editor always do it and a unused method removal.  A separate commit just in case they aren't wanted.

Closes XMLBEANS-582