### PR TITLE
Resolve ambiguous method reference

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
@@ -472,7 +472,7 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
 
     private void assertContainersHelper(Map<QName, SchemaComponent.Ref> comp, Function<SchemaContainer, List<? extends SchemaComponent>> fun, Function<List<? extends SchemaComponent>, ? extends Map<QName, SchemaComponent.Ref>> fun2) {
         final Map<QName, SchemaComponent.Ref> temp = _containers.values().stream()
-            .map(fun).map(fun2 == null ? SchemaTypeSystemImpl::buildComponentRefMap : fun2)
+            .map(fun).map(scs -> fun2 == null ? SchemaTypeSystemImpl.buildComponentRefMap(scs) : fun2.apply(scs) )
             .map(Map::entrySet).flatMap(Set::stream)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         assert comp.equals(temp);


### PR DESCRIPTION
When importing the XMLBeans code into Eclipse, I get the following compile-time errors at this line:

    The method map(Function<? super List<? extends SchemaComponent>,? extends R>) in the type 
    Stream<List<? extends SchemaComponent>> is not applicable for the arguments (((fun2 == null) ?  
    SchemaTypeSystemImpl::buildComponentRefMap : fun2))

    The type of buildComponentRefMap(List<? extends SchemaComponent>) from the type 
    SchemaTypeSystemImpl is Map<QName,SchemaComponent.Ref>, this is incompatible with the 
    descriptor's return type: R

This may well be a quirk of the Eclipse compiler, that it can't resolve ambiguous method references except as a simple argument to the map function, but switching to a lambda seems harmless to me and will help people who use Eclipse to examine the XMLBeans code.