### PR TITLE
Lazy XSD documentation parsing - XMLBEANS-610

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeImpl.java
@@ -2400,7 +2400,7 @@ public final class SchemaTypeImpl implements SchemaType, TypeStoreUserFactory {
     public String getDocumentation()
     {
         if (_documentation == null) {
-            parseDocumentation(_parseObject);
+            _documentation = parseDocumentation(_parseObject);
         }
         return _documentation;
     }

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeImpl.java
@@ -2253,7 +2253,6 @@ public final class SchemaTypeImpl implements SchemaType, TypeStoreUserFactory {
         _elemFormDefault = elemFormDefault;
         _attFormDefault = attFormDefault;
         _redefinition = redefinition;
-        _documentation = parseDocumentation(_parseObject);
     }
 
     public XmlObject getParseObject() {
@@ -2400,6 +2399,9 @@ public final class SchemaTypeImpl implements SchemaType, TypeStoreUserFactory {
 
     public String getDocumentation()
     {
+        if (_documentation == null) {
+            parseDocumentation(_parseObject);
+        }
         return _documentation;
     }
 


### PR DESCRIPTION
Parsing XSD documentation comes at a performance cost which should only
be paid when it's actually necessary. This improvement executes XSD
documentation parsing lazily when it's needed. In practice this parsing
is almost never needed so the performance in most cases is be back to
before XMLBEANS-82.