### PR TITLE
Fix ArrayIndexOutOfBoundException when check bytes in a range [0x80; 0xFF] to be a hex digit

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/HexBin.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/HexBin.java
@@ -55,7 +55,11 @@ public final class HexBin {
      * byte to be tested if it is Base64 alphabet
      */
     static boolean isHex(byte octect) {
-        return (hexNumberTable[octect] != -1);
+        // byte is a signed type and [] operator takes an int as an index.
+        // If use `octect` directly, negative byte will be promoted to the
+        // negative int and ArrayIndexOutOfBoundException will be thrown.
+        // `& 0xFF` will convert negative byte to positive int
+        return (hexNumberTable[octect & 0xFF] != -1);
     }
 
     /**


### PR DESCRIPTION
`byte` is a signed type and the `[]` operator takes an `int` as an index.
When you index array using `byte` index it is promoted to the `int` type. The most significant bit of a `byte` (which is a sign bit) promoted to the `int` resulting in a negative value. As a result `ArrayIndexOutOfBoundException` can be thrown.

Using a `& 0xFF` trick is a standard way to prevent sign promotion and treat `byte` as an unsigned value.