### PR TITLE
xmlbeans supports Chinese tags to generate java source code and build…

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypePool.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypePool.java
@@ -89,7 +89,12 @@ class SchemaTypePool {
         }
         String handle = _componentsToHandles.get(element);
         if (handle == null) {
-            handle = addUniqueHandle(element, NameUtil.upperCamelCase(element.getName().getLocalPart()) + "Element");
+            SchemaType type = element.getType();
+            String javaName = type.getShortJavaName();
+            if (javaName != null && !javaName.isEmpty())
+                handle = addUniqueHandle(element, NameUtil.upperCamelCase(javaName) + "Element");
+            else
+                handle = addUniqueHandle(element, NameUtil.upperCamelCase(element.getName().getLocalPart()) + "Element");
         }
         return handle;
     }
@@ -179,7 +184,10 @@ class SchemaTypePool {
             if (name == null) {
                 baseName = "Anon" + uniq + "Type";
             } else {
-                baseName = NameUtil.upperCamelCase(name.getLocalPart()) + uniq + suffix + "Type";
+                String javaName = type.getShortJavaName();
+                if (javaName == null || javaName.isEmpty())
+                    javaName = name.getLocalPart();
+                baseName = NameUtil.upperCamelCase(javaName) + uniq + suffix + "Type";
             }
 
             handle = addUniqueHandle(type, baseName);

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
@@ -312,7 +312,25 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
 
     void savePointersForComponents(SchemaComponent[] components, String dir) {
         for (SchemaComponent component : components) {
-            savePointerFile(dir + QNameHelper.hexsafedir(component.getName()), _name);
+            String javaName = _localHandles.handleForComponent(component);
+            if (javaName != null && !javaName.isEmpty()) 
+            {
+                QName nameTemp = component.getName();
+                String resultName;
+                if (nameTemp.getNamespaceURI() == null || nameTemp.getNamespaceURI().length() == 0) {
+                       resultName = "_nons/" + QNameHelper.hexsafe(javaName);
+                }
+                else
+                {
+                    resultName = QNameHelper.hexsafe(nameTemp.getNamespaceURI()) + "/"
+                             + QNameHelper.hexsafe(javaName);
+                }
+                savePointerFile(dir + resultName, _name);
+            } 
+            else 
+            {
+                savePointerFile(dir + QNameHelper.hexsafedir(component.getName()), _name);
+            }
         }
     }
 

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscChecker.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscChecker.java
@@ -327,7 +327,7 @@ public class StscChecker {
                     // 5.1 If the {content type} of the complex type definition is a simple type definition, then one of the following must be true:
                     switch (baseType.getContentType()) {
                         case SchemaType.SIMPLE_CONTENT:
-                            // 5.1.1 The {content type} of the {base type definition} must be a simple type definition of which the {content type} is a �valid restriction� as defined in Derivation Valid (Restriction, Simple) (�3.14.6).
+                            // 5.1.1 The {content type} of the {base type definition} must be a simple type definition of which the {content type} is a valid restriction as defined in Derivation Valid (Restriction, Simple) (3.14.6).
                             SchemaType cType = sType.getContentBasedOnType();
                             if (cType != baseType) {
                                 // We have to check that the contentType is legally derived
@@ -345,7 +345,7 @@ public class StscChecker {
                             break;
 
                         case SchemaType.MIXED_CONTENT:
-                            // 5.1.2 The {base type definition} must be mixed and have a particle which is �emptiable� as defined in Particle Emptiable (�3.9.6).
+                            // 5.1.2 The {base type definition} must be mixed and have a particle which is emptiable as defined in Particle Emptiable (3.9.6).
                             if (baseType.getContentModel() != null && !baseType.getContentModel().isSkippable()) {
                                 state.error(XmlErrorCodes.COMPLEX_TYPE_RESTRICTION$SC_AND_MIXED_EMPTIABLE,
                                     null, location);
@@ -368,7 +368,7 @@ public class StscChecker {
                             break;
                         case SchemaType.MIXED_CONTENT:
                         case SchemaType.ELEMENT_CONTENT:
-                            // 5.2.2 The {content type} of the {base type definition} must be elementOnly or mixed and have a particle which is �emptiable� as defined in Particle Emptiable (�3.9.6).
+                            // 5.2.2 The {content type} of the {base type definition} must be elementOnly or mixed and have a particle which is emptiable as defined in Particle Emptiable (3.9.6).
                             if (baseType.getContentModel() != null && !baseType.getContentModel().isSkippable()) {
                                 state.error(XmlErrorCodes.COMPLEX_TYPE_RESTRICTION$EMPTY_AND_ELEMENT_OR_MIXED_EMPTIABLE,
                                     null, location);
@@ -404,7 +404,7 @@ public class StscChecker {
                         return false;
                     }
 
-                    // 5.3 ... then the particle of the complex type definition itself must be a �valid restriction� of the particle of the {content type} of the {base type definition}
+                    // 5.3 ... then the particle of the complex type definition itself must be a valid restriction of the particle of the {content type} of the {base type definition}
                     SchemaParticle baseModel = baseType.getContentModel();
                     SchemaParticle derivedModel = sType.getContentModel();
 
@@ -419,7 +419,7 @@ public class StscChecker {
                         return false;
                     }
 
-                    // 5.3 ...  as defined in Particle Valid (Restriction) (�3.9.6).
+                    // 5.3 ...  as defined in Particle Valid (Restriction) (3.9.6).
                     List<XmlError> errors = new ArrayList<>();
                     boolean isValid = isParticleValidRestriction(baseModel, derivedModel, errors, location);
                     if (!isValid) {
@@ -573,15 +573,15 @@ public class StscChecker {
         assert baseModel.getParticleType() == SchemaParticle.CHOICE;
         assert derivedModel.getParticleType() == SchemaParticle.SEQUENCE;
         // Schema Component Constraint: Particle Derivation OK (Sequence:Choice -- MapAndSum)
-        // For a sequence group particle to be a �valid restriction� of a choice group particle all of the following
+        // For a sequence group particle to be a valid restriction of a choice group particle all of the following
         // must be true:
         // 1 There is a complete functional mapping from the particles in the {particles} of R to the particles in the
-        // {particles} of B such that each particle in the {particles} of R is a �valid restriction� of the particle in
-        // the {particles} of B it maps to as defined by Particle Valid (Restriction) (�3.9.6).
+        // {particles} of B such that each particle in the {particles} of R is a valid restriction of the particle in
+        // the {particles} of B it maps to as defined by Particle Valid (Restriction) (3.9.6).
         // interpretation:  each particle child in derived should have a match in base.
         // 2 The pair consisting of the product of the {min occurs} of R and the length of its {particles} and unbounded
         // if {max occurs} is unbounded otherwise the product of the {max occurs} of R and the length of its {particles}
-        // is a valid restriction of B's occurrence range as defined by Occurrence Range OK (�3.9.6).
+        // is a valid restriction of B's occurrence range as defined by Occurrence Range OK (3.9.6).
         // NOTE: This clause is in principle more restrictive than absolutely necessary, but in practice will cover
         // all the likely cases, and is much easier to specify than the fully general version.
         // NOTE: This case allows the "unfolding" of iterated disjunctions into sequences. It may be particularly useful
@@ -653,12 +653,12 @@ public class StscChecker {
                || (baseModel.getParticleType() == SchemaParticle.SEQUENCE && derivedModel.getParticleType() == SchemaParticle.ELEMENT);
         // Schema Component Constraint: Particle Derivation OK (Elt:All/Choice/Sequence -- RecurseAsIfGroup)
 
-        // For an element declaration particle to be a �valid restriction� of a group particle
+        // For an element declaration particle to be a valid restriction of a group particle
         // (all, choice or sequence) a group particle of the variety corresponding to B's, with {min occurs} and
         // {max occurs} of 1 and with {particles} consisting of a single particle the same as the element declaration
-        // must be a �valid restriction� of the group as defined by Particle Derivation OK
-        // (All:All,Sequence:Sequence -- Recurse) (�3.9.6), Particle Derivation OK (Choice:Choice -- RecurseLax)
-        // (�3.9.6) or Particle Derivation OK (All:All,Sequence:Sequence -- Recurse) (�3.9.6), depending on whether
+        // must be a valid restriction of the group as defined by Particle Derivation OK
+        // (All:All,Sequence:Sequence -- Recurse) (3.9.6), Particle Derivation OK (Choice:Choice -- RecurseLax)
+        // (3.9.6) or Particle Derivation OK (All:All,Sequence:Sequence -- Recurse) (3.9.6), depending on whether
         // the group is all, choice or sequence
 
         // interpretation:  make a fake group of the right type, with min occurs and max occurs of 1
@@ -677,15 +677,15 @@ public class StscChecker {
         assert baseModel.getParticleType() == SchemaParticle.CHOICE && derivedModel.getParticleType() == SchemaParticle.CHOICE;
         boolean recurseLaxValid = true;
         //Schema Component Constraint: Particle Derivation OK (Choice:Choice -- RecurseLax)
-        // For a choice group particle to be a �valid restriction� of another choice group particle all of the
+        // For a choice group particle to be a valid restriction of another choice group particle all of the
         // following must be true:
         // 1 R's occurrence range is a valid restriction of B's occurrence range as defined by Occurrence
-        // Range OK (�3.9.6);
-        // 2 There is a complete �order-preserving� functional mapping from the particles in the {particles} of R
+        // Range OK (3.9.6);
+        // 2 There is a complete order-preserving functional mapping from the particles in the {particles} of R
         // to the particles in the {particles} of B such that each particle in the {particles} of R is a
-        // �valid restriction� of the particle in the {particles} of B it maps to as defined by
-        // Particle Valid (Restriction) (�3.9.6).
-        // NOTE: Although the �validation� semantics of a choice group does not depend on the order of its particles,
+        // valid restriction of the particle in the {particles} of B it maps to as defined by
+        // Particle Valid (Restriction) (3.9.6).
+        // NOTE: Although the validation semantics of a choice group does not depend on the order of its particles,
         // derived choice groups are required to match the order of their base in order to simplify
         // checking that the derivation is OK.
         // interpretation:  check derived choices for match in order, must get an in order match on a base particle,
@@ -736,18 +736,18 @@ public class StscChecker {
         assert baseModel.getParticleType() == SchemaParticle.ALL && derivedModel.getParticleType() == SchemaParticle.SEQUENCE;
         boolean recurseUnorderedValid = true;
         // Schema Component Constraint: Particle Derivation OK (Sequence:All -- RecurseUnordered)
-        // For a sequence group particle to be a �valid restriction� of an all group particle all of the
+        // For a sequence group particle to be a valid restriction of an all group particle all of the
         // following must be true:
         // 1 R's occurrence range is a valid restriction of B's occurrence range as defined by
-        // Occurrence Range OK (�3.9.6).
+        // Occurrence Range OK (3.9.6).
         // 2 There is a complete functional mapping from the particles in the {particles} of R to the particles
         // in the {particles} of B such that all of the following must be true:
         // 2.1 No particle in the {particles} of B is mapped to by more than one of the particles in
         // the {particles} of R;
-        // 2.2 Each particle in the {particles} of R is a �valid restriction� of the particle in the {particles} of B
-        // it maps to as defined by Particle Valid (Restriction) (�3.9.6);
+        // 2.2 Each particle in the {particles} of R is a valid restriction of the particle in the {particles} of B
+        // it maps to as defined by Particle Valid (Restriction) (3.9.6);
         // 2.3 All particles in the {particles} of B which are not mapped to by any particle in the {particles}
-        // of R are �emptiable� as defined by Particle Emptiable (�3.9.6).
+        // of R are emptiable as defined by Particle Emptiable (3.9.6).
         // NOTE: Although this clause allows reordering, because of the limits on the contents of all groups the
         // checking process can still be deterministic.
         // 1, 2.2, and 2.3 are the same as recurse, so do 2.1 and then call recurse
@@ -825,17 +825,17 @@ public class StscChecker {
     private static boolean recurse(SchemaParticle baseModel, SchemaParticle derivedModel, Collection<XmlError> errors, XmlObject context) {
         // recurse is called when base: ALL derived: ALL or base: SEQUENCE derived: SEQUENCE
         boolean recurseValid = true;
-        // For an all or sequence group particle to be a �valid restriction� of another group particle with the same
+        // For an all or sequence group particle to be a valid restriction of another group particle with the same
         // {compositor} all of the following must be true:
         // 1 R's occurrence range is a valid restriction of B's occurrence range as defined by
-        // Occurrence Range OK (�3.9.6).
-        // 2 There is a complete �order-preserving� functional mapping from the particles in the {particles} of R to
+        // Occurrence Range OK (3.9.6).
+        // 2 There is a complete order-preserving functional mapping from the particles in the {particles} of R to
         // the particles in the {particles} of B such that all of the following must be true:
-        //   2.1 Each particle in the {particles} of R is a �valid restriction� of the particle in the {particles}
-        //   of B it maps to as defined by Particle Valid (Restriction) (�3.9.6).
+        //   2.1 Each particle in the {particles} of R is a valid restriction of the particle in the {particles}
+        //   of B it maps to as defined by Particle Valid (Restriction) (3.9.6).
         //   2.2 All particles in the {particles} of B which are not mapped to by any particle in the {particles}
-        //   of R are �emptiable� as defined by Particle Emptiable (�3.9.6).
-        // NOTE: Although the �validation� semantics of an all group does not depend on the order of its particles,
+        //   of R are emptiable as defined by Particle Emptiable (3.9.6).
+        // NOTE: Although the validation semantics of an all group does not depend on the order of its particles,
         // derived all groups are required to match the order of their base in order to simplify checking that
         // the derivation is OK.
         // [Definition:]  A complete functional mapping is order-preserving if each particle r in the domain R maps
@@ -921,8 +921,8 @@ public class StscChecker {
                || (derivedModel.getParticleType() == SchemaParticle.CHOICE)
                || (derivedModel.getParticleType() == SchemaParticle.SEQUENCE);
         boolean nsRecurseCheckCardinality = true;
-        // For a group particle to be a �valid restriction� of a wildcard particle all of the following must be true:
-        // 1 Every member of the {particles} of the group is a �valid restriction� of the wildcard as defined by Particle Valid (Restriction) (�3.9.6).
+        // For a group particle to be a valid restriction of a wildcard particle all of the following must be true:
+        // 1 Every member of the {particles} of the group is a valid restriction of the wildcard as defined by Particle Valid (Restriction) (3.9.6).
         //  Note:  not positive what this means.  Interpreting to mean that every particle of the group must adhere to wildcard derivation rules
         //         in a recursive manner
         //  Loop thru the children particles of the group and invoke the appropriate function to check for wildcard restriction validity
@@ -966,9 +966,9 @@ public class StscChecker {
             }
         }
 
-        // 2 The effective total range of the group, as defined by Effective Total Range (all and sequence) (�3.8.6)
-        // (if the group is all or sequence) or Effective Total Range (choice) (�3.8.6) (if it is choice) is a valid
-        // restriction of B's occurrence range as defined by Occurrence Range OK (�3.9.6).
+        // 2 The effective total range of the group, as defined by Effective Total Range (all and sequence) (3.8.6)
+        // (if the group is all or sequence) or Effective Total Range (choice) (3.8.6) (if it is choice) is a valid
+        // restriction of B's occurrence range as defined by Occurrence Range OK (3.9.6).
 
         if (nsRecurseCheckCardinality) {
             nsRecurseCheckCardinality = checkGroupOccurrenceOK(baseModel, derivedModel, errors, context);
@@ -1278,11 +1278,11 @@ public class StscChecker {
         assert baseModel.getParticleType() == SchemaParticle.WILDCARD;
         assert derivedModel.getParticleType() == SchemaParticle.WILDCARD;
         boolean nsSubset;
-        // For a wildcard particle to be a �valid restriction� of another wildcard particle all of the following must be true:
-        // 1 R's occurrence range must be a valid restriction of B's occurrence range as defined by Occurrence Range OK (�3.9.6).
+        // For a wildcard particle to be a valid restriction of another wildcard particle all of the following must be true:
+        // 1 R's occurrence range must be a valid restriction of B's occurrence range as defined by Occurrence Range OK (3.9.6).
         if (occurrenceRangeOK(baseModel, derivedModel, errors, context)) {
             // 2 R's {namespace constraint} must be an intensional subset of B's {namespace constraint} as defined
-            // by Wildcard Subset (�3.10.6).
+            // by Wildcard Subset (3.10.6).
             if (baseModel.getWildcardSet().inverse().isDisjoint(derivedModel.getWildcardSet())) {
                 nsSubset = true;
             } else {
@@ -1304,11 +1304,11 @@ public class StscChecker {
         // nsCompat is called when base: ANY, derived: ELEMENT
         assert baseModel.getParticleType() == SchemaParticle.WILDCARD;
         boolean nsCompat;
-        // For an element declaration particle to be a �valid restriction� of a wildcard particle all of the following must be true:
-        // 1 The element declaration's {target namespace} is �valid� with respect to the wildcard's {namespace constraint}
-        // as defined by Wildcard allows Namespace Name (�3.10.4).
+        // For an element declaration particle to be a valid restriction of a wildcard particle all of the following must be true:
+        // 1 The element declaration's {target namespace} is valid with respect to the wildcard's {namespace constraint}
+        // as defined by Wildcard allows Namespace Name (3.10.4).
         if (baseModel.getWildcardSet().contains(derivedElement.getName())) {
-            // 2 R's occurrence range is a valid restriction of B's occurrence range as defined by Occurrence Range OK (�3.9.6).
+            // 2 R's occurrence range is a valid restriction of B's occurrence range as defined by Occurrence Range OK (3.9.6).
             nsCompat = occurrenceRangeOK(baseModel, (SchemaParticle) derivedElement, errors, context);
         } else {
             nsCompat = false;
@@ -1339,7 +1339,7 @@ public class StscChecker {
             return false;
         }
 
-        // 3 R's occurrence range is a valid restriction of B's occurrence range as defined by Occurrence Range OK (�3.9.6).
+        // 3 R's occurrence range is a valid restriction of B's occurrence range as defined by Occurrence Range OK (3.9.6).
         if (!occurrenceRangeOK((SchemaParticle) baseElement, (SchemaParticle) derivedElement, errors, context)) {
             // error already produced
             return false;
@@ -1359,7 +1359,7 @@ public class StscChecker {
         }
 
         // 7 R's {type definition} is validly derived given {extension, list, union} from B's {type definition} as
-        // defined by Type Derivation OK (Complex) (�3.4.6) or Type Derivation OK (Simple) (�3.14.6), as appropriate.
+        // defined by Type Derivation OK (Complex) (3.4.6) or Type Derivation OK (Simple) (3.14.6), as appropriate.
         if (!typeDerivationOK(baseElement.getType(), derivedElement.getType(), errors, context)) {
             // error already produced
             return false;
@@ -1398,10 +1398,10 @@ public class StscChecker {
         // 2.1 B and D must be the same type definition.
         // 2.2 B must be D's {base type definition}.
         // 2.3 All of the following must be true:
-        // 2.3.1 D's {base type definition} must not be the �ur-type definition�.
+        // 2.3.1 D's {base type definition} must not be the ur-type definition.
         // 2.3.2 The appropriate case among the following must be true:
         // 2.3.2.1 If D's {base type definition} is complex, then it must be validly derived from B given the subset as defined by this constraint.
-        // 2.3.2.2 If D's {base type definition} is simple, then it must be validly derived from B given the subset as defined in Type Derivation OK (Simple) (�3.14.6).
+        // 2.3.2.2 If D's {base type definition} is simple, then it must be validly derived from B given the subset as defined in Type Derivation OK (Simple) (3.14.6).
         //   This line will check if derivedType is a subType of baseType (should handle all of the 2.xx checks above)
         if (baseType.isAssignableFrom(derivedType)) {
             // Ok derived type is subtype but need to make sure that all of the derivations between the two types are by

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscComplexTypeResolver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscComplexTypeResolver.java
@@ -1002,7 +1002,7 @@ public class StscComplexTypeResolver {
     static SchemaParticle extendContentModel(SchemaParticle baseContentModel, SchemaParticle extendedContentModel, XmlObject parseTree) {
         // http://www.w3.org/TR/xmlschema-1/#element-complexContent::extension
 
-        // 2.1 If the explicit content is empty, then the {content type} of the type definition resolved to by the �actual value� of the base [attribute]
+        // 2.1 If the explicit content is empty, then the {content type} of the type definition resolved to by the actual value of the base [attribute]
         if (extendedContentModel == null) {
             return baseContentModel;
         }

--- a/src/main/java/org/apache/xmlbeans/impl/tool/CodeGenUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/CodeGenUtil.java
@@ -119,6 +119,9 @@ public class CodeGenUtil {
             cp = systemClasspath();
         }
 
+        args.add("-encoding");
+        args.add("utf-8");
+
         if (cp.length > 0) {
             StringBuilder classPath = new StringBuilder();
             // Add the output directory to the classpath.  We do this so that
@@ -159,7 +162,7 @@ public class CodeGenUtil {
         File clFile = null;
         try {
             clFile = Files.createTempFile(IOUtil.getTempDir(), "javac", ".tmp").toFile();
-            try (Writer fw = Files.newBufferedWriter(clFile.toPath(), StandardCharsets.ISO_8859_1)) {
+            try (Writer fw = Files.newBufferedWriter(clFile.toPath(), StandardCharsets.UTF_8)) {
                 Iterator<String> i = args.iterator();
                 for (i.next(); i.hasNext(); ) {
                     String arg = i.next();

--- a/src/main/java/org/apache/xmlbeans/impl/util/FilerImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/FilerImpl.java
@@ -48,7 +48,7 @@ public class FilerImpl implements Filer {
             temp = Charset.forName(System.getProperty("file.encoding"));
         } catch (Exception ignored) {
         }
-        CHARSET = temp;
+        CHARSET = null;
     }
 
     public FilerImpl(File classdir, File srcdir, Repackager repackager, boolean verbose, boolean incrSrcGen) {
@@ -129,7 +129,7 @@ public class FilerImpl implements Filer {
 
     private static Writer writerForFile(File f) throws IOException {
         if (CHARSET == null) {
-            return Files.newBufferedWriter(f.toPath(), StandardCharsets.ISO_8859_1);
+            return Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8);
         }
 
         FileOutputStream fileStream = new FileOutputStream(f);


### PR DESCRIPTION
[Reason: xmlbeans-REL_5_1_1 does not support Chinese paths (essentially, javac on the win platform does not support Chinese source code paths)]
[Changes:
1. handleForElement and handleForType use javaName English name as the path;
2. When building a jar package, the path in the metadata/system directory is changed to javaName English;
3. StscChecker.java and StscComplexTypeResolver.java remove non-utf-8 encoded characters;
4. Add the parameter encoding=utf-8 to the javac compiled code in externalCompile;
5. Use utf-8 encoding for java source code index files;
6. Filer settings are not obtained from the current system (because it is very likely to be GBK when obtained on the win platform), and are manually specified as utf-8]
[Affected area: xmlbeans supports Chinese tags to generate java source code and build jar packages]