### PR TITLE
xmlbeans supports Chinese tags to generate java source code and build JAR package

### DIFF
--- a/src/main/java/org/apache/xmlbeans/Filer.java
+++ b/src/main/java/org/apache/xmlbeans/Filer.java
@@ -39,10 +39,10 @@ public interface Filer
      * Creates a new binding source file (.java) and returns a writer for it.
      *
      * @param typename fully qualified type name
-     * @param useCustomEncoding whether use CustomEncoding
+     * @param sourceCodeEncoding  whether use CustomEncoding
      * @return a stream to write the type to
      *
      * @throws IOException when the file can't be created
      */
-    public Writer createSourceFile(String typename, boolean useCustomEncoding) throws IOException;
+    public Writer createSourceFile(String typename, boolean sourceCodeEncoding ) throws IOException;
 }

--- a/src/main/java/org/apache/xmlbeans/Filer.java
+++ b/src/main/java/org/apache/xmlbeans/Filer.java
@@ -39,10 +39,22 @@ public interface Filer
      * Creates a new binding source file (.java) and returns a writer for it.
      *
      * @param typename fully qualified type name
-     * @param sourceCodeEncoding  whether use CustomEncoding
      * @return a stream to write the type to
      *
      * @throws IOException when the file can't be created
      */
-    public Writer createSourceFile(String typename, boolean sourceCodeEncoding ) throws IOException;
+    default Writer createSourceFile(String typename) throws IOException {
+        return createSourceFile(typename, null);
+    }
+
+    /**
+     * Creates a new binding source file (.java) and returns a writer for it.
+     *
+     * @param typename fully qualified type name
+     * @param sourceCodeEncoding an optional encoding used when compiling source code (can be <code>null</code>)
+     * @return a stream to write the type to
+     *
+     * @throws IOException when the file can't be created
+     */
+    public Writer createSourceFile(String typename, String sourceCodeEncoding) throws IOException;
 }

--- a/src/main/java/org/apache/xmlbeans/Filer.java
+++ b/src/main/java/org/apache/xmlbeans/Filer.java
@@ -39,10 +39,10 @@ public interface Filer
      * Creates a new binding source file (.java) and returns a writer for it.
      *
      * @param typename fully qualified type name
+     * @param useCustomEncoding whether use CustomEncoding
      * @return a stream to write the type to
      *
      * @throws IOException when the file can't be created
      */
-    public Writer createSourceFile(String typename) throws IOException;
-
+    public Writer createSourceFile(String typename, boolean useCustomEncoding) throws IOException;
 }

--- a/src/main/java/org/apache/xmlbeans/FilterXmlObject.java
+++ b/src/main/java/org/apache/xmlbeans/FilterXmlObject.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.zip.ZipOutputStream;
 
 /**
  * A FilterXmlObject delegates to some other XmlObject, which it can use as
@@ -197,6 +198,10 @@ public abstract class FilterXmlObject implements XmlObject, SimpleValue, Delegat
 
     public void save(OutputStream os, XmlOptions options) throws IOException {
         underlyingXmlObject().save(os, options);
+    }
+
+    public void save(ZipOutputStream zos, XmlOptions options) throws IOException {
+        underlyingXmlObject().save(zos, options);
     }
 
     public void save(Writer w, XmlOptions options) throws IOException {

--- a/src/main/java/org/apache/xmlbeans/XmlOptions.java
+++ b/src/main/java/org/apache/xmlbeans/XmlOptions.java
@@ -107,7 +107,7 @@ public class XmlOptions implements java.io.Serializable {
         SAVE_CDATA_LENGTH_THRESHOLD,
         SAVE_CDATA_ENTITY_COUNT_THRESHOLD,
         SAVE_SAX_NO_NSDECLS_IN_ATTRIBUTES,
-        SAVE_EXTRENAMESPACES,
+        SAVE_EXTRA_ENAMESPACES,
         LOAD_REPLACE_DOCUMENT_ELEMENT,
         LOAD_STRIP_WHITESPACE,
         LOAD_STRIP_COMMENTS,
@@ -158,7 +158,7 @@ public class XmlOptions implements java.io.Serializable {
         XPATH_USE_SAXON,
         XPATH_USE_XMLBEANS,
         ATTRIBUTE_VALIDATION_COMPAT_MODE,
-        USE_CUSTOM_ENCODING,
+        SOURCE_CODE_ENCODING,
         USE_SHORT_JAVA_NAME
     }
 
@@ -458,12 +458,12 @@ public class XmlOptions implements java.io.Serializable {
      * @see XmlTokenSource#xmlText(XmlOptions)
      */
     public XmlOptions setSaveExtraNamespaces(Map<String, String> extraNamespaces) {
-        return set(XmlOptionsKeys.SAVE_EXTRENAMESPACES, extraNamespaces);
+        return set(XmlOptionsKeys.SAVE_EXTRA_ENAMESPACES, extraNamespaces);
     }
 
     @SuppressWarnings("unchecked")
     public Map<String, String> getSaveExtraNamespaces() {
-        return (Map<String, String>) get(XmlOptionsKeys.SAVE_EXTRENAMESPACES);
+        return (Map<String, String>) get(XmlOptionsKeys.SAVE_EXTRA_ENAMESPACES);
     }
 
     /**
@@ -1092,16 +1092,16 @@ public class XmlOptions implements java.io.Serializable {
      * If this option is set, then the schema compiler will use utf_8 to generate java source file
      *
      */
-    public XmlOptions setCompileUseCustomEncoding() {
-        return setCompileUseCustomEncoding(true);
+    public XmlOptions setCompileSourceCodeEncoding () {
+        return setCompileSourceCodeEncoding (true);
     }
 
-    public XmlOptions setCompileUseCustomEncoding(boolean b) {
-        return set(XmlOptionsKeys.USE_CUSTOM_ENCODING, b);
+    public XmlOptions setCompileSourceCodeEncoding (boolean b) {
+        return set(XmlOptionsKeys.SOURCE_CODE_ENCODING, b);
     }
 
-    public boolean isCompileUseCustomEncoding() {
-        return hasOption(XmlOptionsKeys.USE_CUSTOM_ENCODING);
+    public boolean isCompileSourceCodeEncoding () {
+        return hasOption(XmlOptionsKeys.SOURCE_CODE_ENCODING);
     }
 
     /**

--- a/src/main/java/org/apache/xmlbeans/XmlOptions.java
+++ b/src/main/java/org/apache/xmlbeans/XmlOptions.java
@@ -107,6 +107,7 @@ public class XmlOptions implements java.io.Serializable {
         SAVE_CDATA_LENGTH_THRESHOLD,
         SAVE_CDATA_ENTITY_COUNT_THRESHOLD,
         SAVE_SAX_NO_NSDECLS_IN_ATTRIBUTES,
+        SAVE_EXTRENAMESPACES,
         LOAD_REPLACE_DOCUMENT_ELEMENT,
         LOAD_STRIP_WHITESPACE,
         LOAD_STRIP_COMMENTS,
@@ -157,7 +158,8 @@ public class XmlOptions implements java.io.Serializable {
         XPATH_USE_SAXON,
         XPATH_USE_XMLBEANS,
         ATTRIBUTE_VALIDATION_COMPAT_MODE,
-
+        USE_CUSTOM_ENCODING,
+        USE_SHORT_JAVA_NAME
     }
 
 
@@ -212,7 +214,6 @@ public class XmlOptions implements java.io.Serializable {
     public boolean isSaveNamespacesFirst() {
         return hasOption(XmlOptionsKeys.SAVE_NAMESPACES_FIRST);
     }
-
 
     /**
      * This option will cause the saver to reformat white space for easier reading.
@@ -446,6 +447,23 @@ public class XmlOptions implements java.io.Serializable {
     @SuppressWarnings("unchecked")
     public Map<String, String> getSaveSuggestedPrefixes() {
         return (Map<String, String>) get(XmlOptionsKeys.SAVE_SUGGESTED_PREFIXES);
+    }
+
+    /**
+     * A map of hints to pass to the saver for which prefixes to use
+     * for which namespace URI.
+     *
+     * @param extraNamespaces a map from URIs to prefixes
+     * @see XmlTokenSource#save(java.io.File, XmlOptions)
+     * @see XmlTokenSource#xmlText(XmlOptions)
+     */
+    public XmlOptions setSaveExtraNamespaces(Map<String, String> extraNamespaces) {
+        return set(XmlOptionsKeys.SAVE_EXTRENAMESPACES, extraNamespaces);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, String> getSaveExtraNamespaces() {
+        return (Map<String, String>) get(XmlOptionsKeys.SAVE_EXTRENAMESPACES);
     }
 
     /**
@@ -1070,6 +1088,37 @@ public class XmlOptions implements java.io.Serializable {
         return hasOption(XmlOptionsKeys.COMPILE_DOWNLOAD_URLS);
     }
 
+    /**
+     * If this option is set, then the schema compiler will use utf_8 to generate java source file
+     *
+     */
+    public XmlOptions setCompileUseCustomEncoding() {
+        return setCompileUseCustomEncoding(true);
+    }
+
+    public XmlOptions setCompileUseCustomEncoding(boolean b) {
+        return set(XmlOptionsKeys.USE_CUSTOM_ENCODING, b);
+    }
+
+    public boolean isCompileUseCustomEncoding() {
+        return hasOption(XmlOptionsKeys.USE_CUSTOM_ENCODING);
+    }
+
+    /**
+     * If this option is set, then the schema compiler will use the java_short_name to generate file name
+     *
+     */
+    public XmlOptions setCompileUseShortJavaName() {
+        return setCompileUseShortJavaName(true);
+    }
+
+    public XmlOptions setCompileUseShortJavaName(boolean b) {
+        return set(XmlOptionsKeys.USE_SHORT_JAVA_NAME, b);
+    }
+
+    public boolean isCompileUseShortJavaName() {
+        return hasOption(XmlOptionsKeys.USE_SHORT_JAVA_NAME);
+    }
     /**
      * If this option is set, then the schema compiler will permit and
      * ignore multiple definitions of the same component (element, attribute,

--- a/src/main/java/org/apache/xmlbeans/XmlOptions.java
+++ b/src/main/java/org/apache/xmlbeans/XmlOptions.java
@@ -107,7 +107,7 @@ public class XmlOptions implements java.io.Serializable {
         SAVE_CDATA_LENGTH_THRESHOLD,
         SAVE_CDATA_ENTITY_COUNT_THRESHOLD,
         SAVE_SAX_NO_NSDECLS_IN_ATTRIBUTES,
-        SAVE_EXTRA_ENAMESPACES,
+        SAVE_EXTRA_NAMESPACES,
         LOAD_REPLACE_DOCUMENT_ELEMENT,
         LOAD_STRIP_WHITESPACE,
         LOAD_STRIP_COMMENTS,
@@ -158,8 +158,7 @@ public class XmlOptions implements java.io.Serializable {
         XPATH_USE_SAXON,
         XPATH_USE_XMLBEANS,
         ATTRIBUTE_VALIDATION_COMPAT_MODE,
-        SOURCE_CODE_ENCODING,
-        USE_SHORT_JAVA_NAME
+        USE_JAVA_SHORT_NAME
     }
 
 
@@ -458,12 +457,12 @@ public class XmlOptions implements java.io.Serializable {
      * @see XmlTokenSource#xmlText(XmlOptions)
      */
     public XmlOptions setSaveExtraNamespaces(Map<String, String> extraNamespaces) {
-        return set(XmlOptionsKeys.SAVE_EXTRA_ENAMESPACES, extraNamespaces);
+        return set(XmlOptionsKeys.SAVE_EXTRA_NAMESPACES, extraNamespaces);
     }
 
     @SuppressWarnings("unchecked")
     public Map<String, String> getSaveExtraNamespaces() {
-        return (Map<String, String>) get(XmlOptionsKeys.SAVE_EXTRA_ENAMESPACES);
+        return (Map<String, String>) get(XmlOptionsKeys.SAVE_EXTRA_NAMESPACES);
     }
 
     /**
@@ -1089,22 +1088,6 @@ public class XmlOptions implements java.io.Serializable {
     }
 
     /**
-     * If this option is set, then the schema compiler will use utf_8 to generate java source file
-     *
-     */
-    public XmlOptions setCompileSourceCodeEncoding () {
-        return setCompileSourceCodeEncoding (true);
-    }
-
-    public XmlOptions setCompileSourceCodeEncoding (boolean b) {
-        return set(XmlOptionsKeys.SOURCE_CODE_ENCODING, b);
-    }
-
-    public boolean isCompileSourceCodeEncoding () {
-        return hasOption(XmlOptionsKeys.SOURCE_CODE_ENCODING);
-    }
-
-    /**
      * If this option is set, then the schema compiler will use the java_short_name to generate file name
      *
      */
@@ -1113,11 +1096,11 @@ public class XmlOptions implements java.io.Serializable {
     }
 
     public XmlOptions setCompileUseShortJavaName(boolean b) {
-        return set(XmlOptionsKeys.USE_SHORT_JAVA_NAME, b);
+        return set(XmlOptionsKeys.USE_JAVA_SHORT_NAME, b);
     }
 
     public boolean isCompileUseShortJavaName() {
-        return hasOption(XmlOptionsKeys.USE_SHORT_JAVA_NAME);
+        return hasOption(XmlOptionsKeys.USE_JAVA_SHORT_NAME);
     }
     /**
      * If this option is set, then the schema compiler will permit and

--- a/src/main/java/org/apache/xmlbeans/XmlTokenSource.java
+++ b/src/main/java/org/apache/xmlbeans/XmlTokenSource.java
@@ -22,6 +22,7 @@ import org.xml.sax.ext.LexicalHandler;
 
 import javax.xml.stream.XMLStreamReader;
 import java.io.*;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Represents a holder of XML that can return an {@link XmlCursor}
@@ -169,6 +170,14 @@ public interface XmlTokenSource {
      * with the XML.
      */
     void save(OutputStream os) throws IOException;
+
+    /**
+     * Writes the XML represented by this source to the given zip output stream.
+     * This method will save the XML declaration, including encoding information,
+     * with the XML.
+     */
+    void save(ZipOutputStream os) throws IOException;
+
 
     /**
      * Writes the XML represented by this source to the given output.
@@ -335,6 +344,13 @@ public interface XmlTokenSource {
      * with the XML.
      */
     void save(OutputStream os, XmlOptions options) throws IOException;
+
+    /**
+     * Writes the XML represented by this source to the given zip output stream.
+     * This method will save the XML declaration, including encoding information,
+     * with the XML.
+     */
+    void save(ZipOutputStream os, XmlOptions options) throws IOException;
 
     /**
      * Writes the XML represented by this source to the given output.

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypePool.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypePool.java
@@ -89,7 +89,17 @@ class SchemaTypePool {
         }
         String handle = _componentsToHandles.get(element);
         if (handle == null) {
-            handle = addUniqueHandle(element, NameUtil.upperCamelCase(element.getName().getLocalPart()) + "Element");
+            if(typeSystem.getUseShortName()) {
+                SchemaType type = element.getType();
+                String javaName = type.getShortJavaName();
+                if (javaName != null && !javaName.isEmpty()) {
+                    handle = addUniqueHandle(element, NameUtil.upperCamelCase(javaName) + "Element");
+                } else {
+                    handle = addUniqueHandle(element, NameUtil.upperCamelCase(element.getName().getLocalPart()) + "Element");
+                }
+            } else {
+                handle = addUniqueHandle(element, NameUtil.upperCamelCase(element.getName().getLocalPart()) + "Element");
+            }
         }
         return handle;
     }
@@ -179,7 +189,15 @@ class SchemaTypePool {
             if (name == null) {
                 baseName = "Anon" + uniq + "Type";
             } else {
-                baseName = NameUtil.upperCamelCase(name.getLocalPart()) + uniq + suffix + "Type";
+                if(typeSystem.getUseShortName()) {
+                    String javaName = type.getShortJavaName();
+                    if (javaName == null || javaName.isEmpty())
+                        javaName = name.getLocalPart();
+                    baseName = NameUtil.upperCamelCase(javaName) + uniq + suffix + "Type";
+                }
+                else {
+                    baseName = NameUtil.upperCamelCase(name.getLocalPart()) + uniq + suffix + "Type";
+                }
             }
 
             handle = addUniqueHandle(type, baseName);

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypePool.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypePool.java
@@ -89,7 +89,7 @@ class SchemaTypePool {
         }
         String handle = _componentsToHandles.get(element);
         if (handle == null) {
-            if(typeSystem.getUseShortName()) {
+            if(typeSystem.isUseJavaShortName()) {
                 SchemaType type = element.getType();
                 String javaName = type.getShortJavaName();
                 if (javaName != null && !javaName.isEmpty()) {
@@ -189,7 +189,7 @@ class SchemaTypePool {
             if (name == null) {
                 baseName = "Anon" + uniq + "Type";
             } else {
-                if(typeSystem.getUseShortName()) {
+                if(typeSystem.isUseJavaShortName()) {
                     String javaName = type.getShortJavaName();
                     if (javaName == null || javaName.isEmpty())
                         javaName = name.getLocalPart();

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemCompiler.java
@@ -380,7 +380,7 @@ public class SchemaTypeSystemCompiler {
 
         String indexClassName = SchemaTypeCodePrinter.indexClassForSystem(system);
 
-        try (Writer out = filer.createSourceFile(indexClassName)) {
+        try (Writer out = filer.createSourceFile(indexClassName, (options == null) ? false : options.isCompileUseCustomEncoding())) {
             Repackager repackager = (filer instanceof FilerImpl) ? ((FilerImpl) filer).getRepackager() : null;
             printer.printHolder(out, system, options, repackager);
         } catch (IOException e) {
@@ -398,7 +398,7 @@ public class SchemaTypeSystemCompiler {
 
             String fjn = type.getFullJavaName();
 
-            try (Writer writer = filer.createSourceFile(fjn)) {
+            try (Writer writer = filer.createSourceFile(fjn, (options == null) ? false : options.isCompileUseCustomEncoding())) {
                 // Generate interface class
                 printer.printType(writer, type, options);
             } catch (IOException e) {
@@ -408,7 +408,7 @@ public class SchemaTypeSystemCompiler {
 
             fjn = type.getFullJavaImplName();
 
-            try (Writer writer = filer.createSourceFile(fjn)) {
+            try (Writer writer = filer.createSourceFile(fjn, (options == null) ? false : options.isCompileUseCustomEncoding())) {
                 // Generate Implementation class
                 printer.printTypeImpl(writer, type, options);
             } catch (IOException e) {

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemCompiler.java
@@ -373,14 +373,14 @@ public class SchemaTypeSystemCompiler {
         types.addAll(Arrays.asList(system.attributeTypes()));
 
 
-        SchemaCodePrinter printer = (options == null) ? null : options.getSchemaCodePrinter();
+        SchemaCodePrinter printer = options == null ? null : options.getSchemaCodePrinter();
         if (printer == null) {
             printer = new SchemaTypeCodePrinter();
         }
 
         String indexClassName = SchemaTypeCodePrinter.indexClassForSystem(system);
 
-        try (Writer out = filer.createSourceFile(indexClassName, (options == null) ? false : options.isCompileSourceCodeEncoding())) {
+        try (Writer out = filer.createSourceFile(indexClassName, options == null ? null : options.getCharacterEncoding())) {
             Repackager repackager = (filer instanceof FilerImpl) ? ((FilerImpl) filer).getRepackager() : null;
             printer.printHolder(out, system, options, repackager);
         } catch (IOException e) {
@@ -398,7 +398,7 @@ public class SchemaTypeSystemCompiler {
 
             String fjn = type.getFullJavaName();
 
-            try (Writer writer = filer.createSourceFile(fjn, (options == null) ? false : options.isCompileSourceCodeEncoding())) {
+            try (Writer writer = filer.createSourceFile(fjn, options == null ? null : options.getCharacterEncoding())) {
                 // Generate interface class
                 printer.printType(writer, type, options);
             } catch (IOException e) {
@@ -408,7 +408,7 @@ public class SchemaTypeSystemCompiler {
 
             fjn = type.getFullJavaImplName();
 
-            try (Writer writer = filer.createSourceFile(fjn, (options == null) ? false : options.isCompileSourceCodeEncoding())) {
+            try (Writer writer = filer.createSourceFile(fjn, options == null ? null : options.getCharacterEncoding())) {
                 // Generate Implementation class
                 printer.printTypeImpl(writer, type, options);
             } catch (IOException e) {

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemCompiler.java
@@ -380,7 +380,7 @@ public class SchemaTypeSystemCompiler {
 
         String indexClassName = SchemaTypeCodePrinter.indexClassForSystem(system);
 
-        try (Writer out = filer.createSourceFile(indexClassName, (options == null) ? false : options.isCompileUseCustomEncoding())) {
+        try (Writer out = filer.createSourceFile(indexClassName, (options == null) ? false : options.isCompileSourceCodeEncoding())) {
             Repackager repackager = (filer instanceof FilerImpl) ? ((FilerImpl) filer).getRepackager() : null;
             printer.printHolder(out, system, options, repackager);
         } catch (IOException e) {
@@ -398,7 +398,7 @@ public class SchemaTypeSystemCompiler {
 
             String fjn = type.getFullJavaName();
 
-            try (Writer writer = filer.createSourceFile(fjn, (options == null) ? false : options.isCompileUseCustomEncoding())) {
+            try (Writer writer = filer.createSourceFile(fjn, (options == null) ? false : options.isCompileSourceCodeEncoding())) {
                 // Generate interface class
                 printer.printType(writer, type, options);
             } catch (IOException e) {
@@ -408,7 +408,7 @@ public class SchemaTypeSystemCompiler {
 
             fjn = type.getFullJavaImplName();
 
-            try (Writer writer = filer.createSourceFile(fjn, (options == null) ? false : options.isCompileUseCustomEncoding())) {
+            try (Writer writer = filer.createSourceFile(fjn, (options == null) ? false : options.isCompileSourceCodeEncoding())) {
                 // Generate Implementation class
                 printer.printTypeImpl(writer, type, options);
             } catch (IOException e) {

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
@@ -163,7 +163,7 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
     private Set<String> _namespaces;
 
     // the additional config option
-    private boolean _useCustom;
+    private boolean _sourceCodeEncoding ;
     private boolean _useShortName;
 
     static String nameToPathString(String nameForSystem) {
@@ -431,8 +431,8 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
         return result;
     }
 
-    Boolean getUseCustomEncoding(){
-        return _useCustom;
+    Boolean getSourceCodeEncoding (){
+        return _sourceCodeEncoding ;
     }
 
     Boolean getUseShortName(){
@@ -644,7 +644,7 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
         _namespaces = new HashSet<>(Arrays.asList(state.getNamespaces()));
         _containers = state.getContainerMap();
         _useShortName = state.useShortName();
-        _useCustom = state.useCustom();
+        _sourceCodeEncoding  = state.sourceCodeEncoding();
         fixupContainers();
         // Checks that data in the containers matches the lookup maps
         assertContainersSynchronized();

--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
@@ -163,8 +163,8 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
     private Set<String> _namespaces;
 
     // the additional config option
-    private boolean _sourceCodeEncoding ;
-    private boolean _useShortName;
+    private String _sourceCodeEncoding ;
+    private boolean _useJavaShortName;
 
     static String nameToPathString(String nameForSystem) {
         nameForSystem = nameForSystem.replace('.', '/');
@@ -314,7 +314,7 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
 
     void savePointersForComponents(SchemaComponent[] components, String dir) {
         for (SchemaComponent component : components) {
-            if(_useShortName) {
+            if(_useJavaShortName) {
                 String javaName = _localHandles.handleForComponent(component);
                 if (javaName != null && !javaName.isEmpty()) 
                 {
@@ -431,12 +431,12 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
         return result;
     }
 
-    Boolean getSourceCodeEncoding (){
+    String getSourceCodeEncoding() {
         return _sourceCodeEncoding ;
     }
 
-    Boolean getUseShortName(){
-        return _useShortName;
+    Boolean isUseJavaShortName() {
+        return _useJavaShortName;
     }
 
     @SuppressWarnings("unchecked")
@@ -643,7 +643,7 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
         _annotations = state.annotations();
         _namespaces = new HashSet<>(Arrays.asList(state.getNamespaces()));
         _containers = state.getContainerMap();
-        _useShortName = state.useShortName();
+        _useJavaShortName = state.useShortName();
         _sourceCodeEncoding  = state.sourceCodeEncoding();
         fixupContainers();
         // Checks that data in the containers matches the lookup maps

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
@@ -104,7 +104,7 @@ public class StscState {
     private boolean _noAnn;
     private boolean _mdefAll;
     private boolean _useShortName;
-    private boolean _useCustom;
+    private boolean _sourceCodeEncoding ;
     private final Set<String> _mdefNamespaces = buildDefaultMdefNamespaces();
     private EntityResolver _entityResolver;
     private File _schemasDir;
@@ -461,8 +461,8 @@ public class StscState {
                  !"true".equals(SystemProperties.getProperty("xmlbean.schemaannotations", "true"));
         _doingDownloads = options.isCompileDownloadUrls() ||
                           "true".equals(SystemProperties.getProperty("xmlbean.downloadurls", "false"));
-        _useCustom = options.isCompileUseCustomEncoding() ||
-                        "true".equals(SystemProperties.getProperty("xmlbean.usecustomencoding", "false"));
+        _sourceCodeEncoding  = options.isCompileSourceCodeEncoding() ||
+                        "true".equals(SystemProperties.getProperty("xmlbean.sourcecodeencoding ", "false"));
         _useShortName = options.isCompileUseShortJavaName() ||
                         "true".equals(SystemProperties.getProperty("xmlbean.useshortjavaname", "false"));
         _entityResolver = options.getEntityResolver();
@@ -533,8 +533,8 @@ public class StscState {
      * True if use customEncoding to generate the java source file
      */
     // EXPERIMENTAL
-    public boolean useCustom() {
-        return _useCustom;
+    public boolean sourceCodeEncoding () {
+        return _sourceCodeEncoding ;
     }
 
     /**

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
@@ -103,6 +103,8 @@ public class StscState {
     private boolean _noPvr;
     private boolean _noAnn;
     private boolean _mdefAll;
+    private boolean _useShortName;
+    private boolean _useCustom;
     private final Set<String> _mdefNamespaces = buildDefaultMdefNamespaces();
     private EntityResolver _entityResolver;
     private File _schemasDir;
@@ -459,6 +461,10 @@ public class StscState {
                  !"true".equals(SystemProperties.getProperty("xmlbean.schemaannotations", "true"));
         _doingDownloads = options.isCompileDownloadUrls() ||
                           "true".equals(SystemProperties.getProperty("xmlbean.downloadurls", "false"));
+        _useCustom = options.isCompileUseCustomEncoding() ||
+                        "true".equals(SystemProperties.getProperty("xmlbean.usecustomencoding", "false"));
+        _useShortName = options.isCompileUseShortJavaName() ||
+                        "true".equals(SystemProperties.getProperty("xmlbean.useshortjavaname", "false"));
         _entityResolver = options.getEntityResolver();
 
         if (_entityResolver == null) {
@@ -521,6 +527,22 @@ public class StscState {
     // EXPERIMENTAL
     public boolean allowPartial() {
         return _allowPartial;
+    }
+
+    /**
+     * True if use customEncoding to generate the java source file
+     */
+    // EXPERIMENTAL
+    public boolean useCustom() {
+        return _useCustom;
+    }
+
+    /**
+     * True if use the java_short_name to generate file name
+     */
+    // EXPERIMENTAL
+    public boolean useShortName() {
+        return _useShortName;
     }
 
     /**

--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscState.java
@@ -103,8 +103,8 @@ public class StscState {
     private boolean _noPvr;
     private boolean _noAnn;
     private boolean _mdefAll;
-    private boolean _useShortName;
-    private boolean _sourceCodeEncoding ;
+    private boolean _useJavaShortName;
+    private String _sourceCodeEncoding ;
     private final Set<String> _mdefNamespaces = buildDefaultMdefNamespaces();
     private EntityResolver _entityResolver;
     private File _schemasDir;
@@ -461,9 +461,11 @@ public class StscState {
                  !"true".equals(SystemProperties.getProperty("xmlbean.schemaannotations", "true"));
         _doingDownloads = options.isCompileDownloadUrls() ||
                           "true".equals(SystemProperties.getProperty("xmlbean.downloadurls", "false"));
-        _sourceCodeEncoding  = options.isCompileSourceCodeEncoding() ||
-                        "true".equals(SystemProperties.getProperty("xmlbean.sourcecodeencoding ", "false"));
-        _useShortName = options.isCompileUseShortJavaName() ||
+        _sourceCodeEncoding = options.getCharacterEncoding();
+        if (_sourceCodeEncoding == null || _sourceCodeEncoding.isEmpty()) {
+            _sourceCodeEncoding = SystemProperties.getProperty("xmlbean.sourcecodeencoding");
+        }
+        _useJavaShortName = options.isCompileUseShortJavaName() ||
                         "true".equals(SystemProperties.getProperty("xmlbean.useshortjavaname", "false"));
         _entityResolver = options.getEntityResolver();
 
@@ -530,10 +532,10 @@ public class StscState {
     }
 
     /**
-     * True if use customEncoding to generate the java source file
+     * An optional encoding to use when compiling generated java source file (can be <code>null</code>)
      */
     // EXPERIMENTAL
-    public boolean sourceCodeEncoding () {
+    public String sourceCodeEncoding () {
         return _sourceCodeEncoding ;
     }
 
@@ -542,7 +544,7 @@ public class StscState {
      */
     // EXPERIMENTAL
     public boolean useShortName() {
-        return _useShortName;
+        return _useJavaShortName;
     }
 
     /**

--- a/src/main/java/org/apache/xmlbeans/impl/store/Cursor.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Cursor.java
@@ -36,6 +36,7 @@ import java.io.*;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.zip.ZipOutputStream;
 
 public final class Cursor implements XmlCursor, ChangeListener {
     static final int ROOT = Cur.ROOT;
@@ -509,6 +510,10 @@ public final class Cursor implements XmlCursor, ChangeListener {
         _save(os, null);
     }
 
+    public void _save(ZipOutputStream zos) throws IOException {
+        _save(zos, null);
+    }
+
     public void _save(Writer w) throws IOException {
         _save(w, null);
     }
@@ -574,6 +579,26 @@ public final class Cursor implements XmlCursor, ChangeListener {
                 }
 
                 os.write(bytes, 0, n);
+            }
+        }
+    }
+
+    public void _save(ZipOutputStream zos, XmlOptions options) throws IOException {
+        if (zos == null) {
+            throw new IllegalArgumentException("Null ZipOutputStream specified");
+        }
+
+        try (InputStream is = _newInputStream(options)) {
+            byte[] bytes = new byte[8192];
+
+            for (; ; ) {
+                int n = is.read(bytes);
+
+                if (n < 0) {
+                    break;
+                }
+
+                zos.write(bytes, 0, n);
             }
         }
     }
@@ -1974,6 +1999,10 @@ public final class Cursor implements XmlCursor, ChangeListener {
         syncWrapIOEx(() -> _save(os));
     }
 
+    public void save(ZipOutputStream zos) throws IOException {
+        syncWrapIOEx(() -> _save(zos));
+    }
+
     public void save(Writer w) throws IOException {
         syncWrapIOEx(() -> _save(w));
     }
@@ -2004,6 +2033,10 @@ public final class Cursor implements XmlCursor, ChangeListener {
 
     public void save(OutputStream os, XmlOptions options) throws IOException {
         syncWrapIOEx(() -> _save(os, options));
+    }
+
+    public void save(ZipOutputStream zos, XmlOptions options) throws IOException {
+        syncWrapIOEx(() -> _save(zos, options));
     }
 
     public void save(Writer w, XmlOptions options) throws IOException {

--- a/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
@@ -43,6 +43,9 @@ abstract class Saver {
     private final long _version;
 
     private SaveCur _cur;
+    
+    protected boolean _isTopLevelElement = true;
+    protected final Map<String, String> _extraNamespaces;
 
     private List<String> _ancestorNamespaces;
     private final Map<String, String> _suggestedPrefixes;
@@ -133,6 +136,8 @@ abstract class Saver {
         _suggestedPrefixes = options.getSaveSuggestedPrefixes();
 
         _ancestorNamespaces = _cur.getAncestorNamespaces();
+
+        _extraNamespaces = options.getSaveExtraNamespaces();
     }
 
     private static SaveCur createSaveCur(Cur c, XmlOptions options) {
@@ -285,10 +290,12 @@ abstract class Saver {
         switch (_cur.kind()) {
             case ROOT: {
                 processRoot();
+                _isTopLevelElement = true;
                 break;
             }
             case ELEM: {
                 processElement();
+                _isTopLevelElement = false;
                 break;
             }
             case -ELEM: {
@@ -897,6 +904,8 @@ abstract class Saver {
                 emitNamespacesHelper();
             }
 
+            emitExtraNamespacesHelper();
+
             for (int i = 0; i < attrNames.size(); i++) {
                 emitAttrHelper(attrNames.get(i), attrValues.get(i));
             }
@@ -939,6 +948,17 @@ abstract class Saver {
             entitizeAttrValue(false);
 
             emit('"');
+        }
+
+        private void emitExtraNamespacesHelper() {
+            if (!_isTopLevelElement || null == _extraNamespaces)
+                return;
+            
+            for (Map.Entry<String, String> nsEntry : _extraNamespaces.entrySet()) {
+                emit(' ');
+                emitXmlns(nsEntry.getKey(), nsEntry.getValue());
+            }
+            
         }
 
         private void emitNamespacesHelper() {
@@ -1848,6 +1868,8 @@ abstract class Saver {
             emit('<');
             emitName(c.getName(), false);
 
+            emitExtraNamespacesHelper();
+
             for (int i = 0; i < attrNames.size(); i++) {
                 emitAttrHelper(attrNames.get(i), attrValues.get(i));
             }
@@ -1894,6 +1916,15 @@ abstract class Saver {
             for (iterateMappings(); hasMapping(); nextMapping()) {
                 emit(' ');
                 emitXmlns(mappingPrefix(), mappingUri());
+            }
+        }
+
+        private void emitExtraNamespacesHelper() {
+            if (!_isTopLevelElement || null == _extraNamespaces)
+                return;
+            for (Map.Entry<String, String> nsEntry : _extraNamespaces.entrySet()) {
+                emit(' ');
+                emitXmlns(nsEntry.getKey(), nsEntry.getValue());
             }
         }
 
@@ -2570,6 +2601,15 @@ abstract class Saver {
             return prefix + ":" + local;
         }
 
+        private void emitExtraNamespacesHelper() {
+            if (!_isTopLevelElement || null == _extraNamespaces|| !_nsAsAttrs)
+                return;
+            for (Map.Entry<String, String> nsEntry : _extraNamespaces.entrySet()) {
+                String prefix = nsEntry.getKey();
+                _attributes.addAttribute("http://www.w3.org/2000/xmlns/", prefix, "xmlns:" + prefix , "CDATA", nsEntry.getValue());
+            }
+        }
+
         private void emitNamespacesHelper() {
             for (iterateMappings(); hasMapping(); nextMapping()) {
                 String prefix = mappingPrefix();
@@ -2598,6 +2638,8 @@ abstract class Saver {
             if (saveNamespacesFirst()) {
                 emitNamespacesHelper();
             }
+
+            emitExtraNamespacesHelper();
 
             for (int i = 0; i < attrNames.size(); i++) {
                 QName name = attrNames.get(i);

--- a/src/main/java/org/apache/xmlbeans/impl/tool/CodeGenUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/CodeGenUtil.java
@@ -91,8 +91,8 @@ public class CodeGenUtil {
     }
 
     // KHK: temporary to avoid build break
-    public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug, String javacPath, String memStart, String memMax, boolean quiet, boolean verbose, boolean useCustom) {
-        return externalCompile(srcFiles, outdir, cp, debug, javacPath, null, memStart, memMax, quiet, verbose, useCustom);
+    public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug, String javacPath, String memStart, String memMax, boolean quiet, boolean verbose, boolean sourceCodeEncoding) {
+        return externalCompile(srcFiles, outdir, cp, debug, javacPath, null, memStart, memMax, quiet, verbose, sourceCodeEncoding);
     }
 
     /**
@@ -101,7 +101,7 @@ public class CodeGenUtil {
      * {@code GenFile}s for all of the classes produced or null if an
      * error occurred.
      */
-    public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug, String javacPath, String genver, String memStart, String memMax, boolean quiet, boolean verbose, boolean useCustom) {
+    public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug, String javacPath, String genver, String memStart, String memMax, boolean quiet, boolean verbose, boolean sourceCodeEncoding) {
         List<String> args = new ArrayList<>();
 
         File javac = findJavaTool(javacPath == null ? DEFAULT_COMPILER : javacPath);
@@ -119,7 +119,7 @@ public class CodeGenUtil {
             cp = systemClasspath();
         }
 
-        if(useCustom) {
+        if(sourceCodeEncoding) {
             args.add("-encoding");
             args.add("utf-8");
         }
@@ -164,7 +164,7 @@ public class CodeGenUtil {
         File clFile = null;
         try {
             clFile = Files.createTempFile(IOUtil.getTempDir(), "javac", ".tmp").toFile();
-            try (Writer fw = Files.newBufferedWriter(clFile.toPath(), useCustom ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1)) {
+            try (Writer fw = Files.newBufferedWriter(clFile.toPath(), sourceCodeEncoding ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1)) {
                 Iterator<String> i = args.iterator();
                 for (i.next(); i.hasNext(); ) {
                     String arg = i.next();

--- a/src/main/java/org/apache/xmlbeans/impl/tool/CodeGenUtil.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/CodeGenUtil.java
@@ -87,12 +87,12 @@ public class CodeGenUtil {
      * @deprecated
      */
     public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug) {
-        return externalCompile(srcFiles, outdir, cp, debug, DEFAULT_COMPILER, null, DEFAULT_MEM_START, DEFAULT_MEM_MAX, false, false);
+        return externalCompile(srcFiles, outdir, cp, debug, DEFAULT_COMPILER, null, DEFAULT_MEM_START, DEFAULT_MEM_MAX, false, false, false);
     }
 
     // KHK: temporary to avoid build break
-    public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug, String javacPath, String memStart, String memMax, boolean quiet, boolean verbose) {
-        return externalCompile(srcFiles, outdir, cp, debug, javacPath, null, memStart, memMax, quiet, verbose);
+    public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug, String javacPath, String memStart, String memMax, boolean quiet, boolean verbose, boolean useCustom) {
+        return externalCompile(srcFiles, outdir, cp, debug, javacPath, null, memStart, memMax, quiet, verbose, useCustom);
     }
 
     /**
@@ -101,7 +101,7 @@ public class CodeGenUtil {
      * {@code GenFile}s for all of the classes produced or null if an
      * error occurred.
      */
-    public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug, String javacPath, String genver, String memStart, String memMax, boolean quiet, boolean verbose) {
+    public static boolean externalCompile(List<File> srcFiles, File outdir, File[] cp, boolean debug, String javacPath, String genver, String memStart, String memMax, boolean quiet, boolean verbose, boolean useCustom) {
         List<String> args = new ArrayList<>();
 
         File javac = findJavaTool(javacPath == null ? DEFAULT_COMPILER : javacPath);
@@ -117,6 +117,11 @@ public class CodeGenUtil {
 
         if (cp == null) {
             cp = systemClasspath();
+        }
+
+        if(useCustom) {
+            args.add("-encoding");
+            args.add("utf-8");
         }
 
         if (cp.length > 0) {
@@ -159,7 +164,7 @@ public class CodeGenUtil {
         File clFile = null;
         try {
             clFile = Files.createTempFile(IOUtil.getTempDir(), "javac", ".tmp").toFile();
-            try (Writer fw = Files.newBufferedWriter(clFile.toPath(), StandardCharsets.ISO_8859_1)) {
+            try (Writer fw = Files.newBufferedWriter(clFile.toPath(), useCustom ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1)) {
                 Iterator<String> i = args.iterator();
                 for (i.next(); i.hasNext(); ) {
                     String arg = i.next();

--- a/src/main/java/org/apache/xmlbeans/impl/tool/Parameters.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/Parameters.java
@@ -55,7 +55,7 @@ public class Parameters {
     private boolean debug;
     private boolean copyAnn;
     private boolean useShortName;
-    private boolean useCustom;
+    private boolean sourceCodeEncoding;
     private boolean incrementalSrcGen;
     private String repackage;
     private List<Extension> extensions = Collections.emptyList();
@@ -209,8 +209,8 @@ public class Parameters {
         return useShortName;
     }
 
-    public boolean isUseCustom() {
-        return useCustom;
+    public boolean isSourceCodeEncoding() {
+        return sourceCodeEncoding;
     }
 
     public void setNoAnn(boolean noAnn) {
@@ -253,8 +253,8 @@ public class Parameters {
         this.useShortName = useShortName;
     }
 
-    public void setUseCustom(boolean useCustom) {
-        this.useCustom = useCustom;
+    public void setSourceCodeEncoding(boolean sourceCodeEncoding) {
+        this.sourceCodeEncoding = sourceCodeEncoding;
     }
 
     public String getMemoryInitialSize() {

--- a/src/main/java/org/apache/xmlbeans/impl/tool/Parameters.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/Parameters.java
@@ -54,6 +54,8 @@ public class Parameters {
     private boolean noExt;
     private boolean debug;
     private boolean copyAnn;
+    private boolean useShortName;
+    private boolean useCustom;
     private boolean incrementalSrcGen;
     private String repackage;
     private List<Extension> extensions = Collections.emptyList();
@@ -203,6 +205,14 @@ public class Parameters {
         return noAnn;
     }
 
+    public boolean isUseShortName() {
+        return useShortName;
+    }
+
+    public boolean isUseCustom() {
+        return useCustom;
+    }
+
     public void setNoAnn(boolean noAnn) {
         this.noAnn = noAnn;
     }
@@ -237,6 +247,14 @@ public class Parameters {
 
     public void setDebug(boolean debug) {
         this.debug = debug;
+    }
+
+    public void setUseShortName(boolean useShortName) {
+        this.useShortName = useShortName;
+    }
+
+    public void setUseCustom(boolean useCustom) {
+        this.useCustom = useCustom;
     }
 
     public String getMemoryInitialSize() {

--- a/src/main/java/org/apache/xmlbeans/impl/tool/Parameters.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/Parameters.java
@@ -55,7 +55,7 @@ public class Parameters {
     private boolean debug;
     private boolean copyAnn;
     private boolean useShortName;
-    private boolean sourceCodeEncoding;
+    private String sourceCodeEncoding;
     private boolean incrementalSrcGen;
     private String repackage;
     private List<Extension> extensions = Collections.emptyList();
@@ -209,7 +209,7 @@ public class Parameters {
         return useShortName;
     }
 
-    public boolean isSourceCodeEncoding() {
+    public String getSourceCodeEncoding() {
         return sourceCodeEncoding;
     }
 
@@ -253,7 +253,7 @@ public class Parameters {
         this.useShortName = useShortName;
     }
 
-    public void setSourceCodeEncoding(boolean sourceCodeEncoding) {
+    public void setSourceCodeEncoding(String sourceCodeEncoding) {
         this.sourceCodeEncoding = sourceCodeEncoding;
     }
 

--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
@@ -186,6 +186,8 @@ public class SchemaCompiler {
         boolean nojavac = (cl.getOpt("srconly") != null);
         boolean debug = (cl.getOpt("debug") != null);
         boolean copyAnn = (cl.getOpt("copyann") != null);
+        boolean useCustom = (cl.getOpt("usecustom") != null);
+        boolean useShortName = (cl.getOpt("useshortname") != null);
 
         String allowmdef = cl.getOpt("allowmdef");
         Set<String> mdefNamespaces = (allowmdef == null ? Collections.emptySet() :
@@ -333,6 +335,8 @@ public class SchemaCompiler {
         params.setNoVDoc(noVDoc);
         params.setNoExt(noExt);
         params.setDebug(debug);
+        params.setUseCustom(useCustom);
+        params.setUseShortName(useShortName);
         params.setErrorListener(err);
         params.setRepackage(repackage);
         params.setExtensions(extensions);
@@ -356,7 +360,7 @@ public class SchemaCompiler {
 
     private static SchemaTypeSystem loadTypeSystem(String name, File[] xsdFiles, File[] wsdlFiles, URL[] urlFiles, File[] configFiles,
                                                    File[] javaFiles, ResourceLoader cpResourceLoader,
-                                                   boolean download, boolean noUpa, boolean noPvr, boolean noAnn, boolean noVDoc, boolean noExt,
+                                                   boolean download, boolean noUpa, boolean noPvr, boolean noAnn, boolean noVDoc, boolean noExt, boolean useCustom, boolean useShortName,
                                                    Set<String> mdefNamespaces, File baseDir, Map<String, String> sourcesToCopyMap,
                                                    Collection<XmlError> outerErrorListener, File schemasDir, EntityResolver entResolver, File[] classpath) {
         XmlErrorWatcher errorListener = new XmlErrorWatcher(outerErrorListener);
@@ -521,6 +525,12 @@ public class SchemaCompiler {
             if (noAnn) {
                 opts.setCompileNoAnnotations();
             }
+            if (useCustom) {
+                opts.setCompileUseCustomEncoding();
+            }
+            if (useShortName) {
+                opts.setCompileUseShortJavaName();
+            }
             if (mdefNamespaces != null) {
                 opts.setCompileMdefNamespaces(mdefNamespaces);
             }
@@ -614,6 +624,8 @@ public class SchemaCompiler {
         boolean noExt = params.isNoExt();
         boolean incrSrcGen = params.isIncrementalSrcGen();
         boolean copyAnn = params.isCopyAnn();
+        boolean useCustom = params.isUseCustom();
+        boolean useShortName = params.isUseShortName();
         Collection<XmlError> outerErrorListener = params.getErrorListener();
         Set<BeanMethod> partialMethods = params.getPartialMethods();
 
@@ -666,7 +678,7 @@ public class SchemaCompiler {
         // build the in-memory type system
         XmlErrorWatcher errorListener = new XmlErrorWatcher(outerErrorListener);
         SchemaTypeSystem system = loadTypeSystem(name, xsdFiles, wsdlFiles, urlFiles, configFiles,
-            javaFiles, cpResourceLoader, download, noUpa, noPvr, noAnn, noVDoc, noExt, mdefNamespaces,
+            javaFiles, cpResourceLoader, download, noUpa, noPvr, noAnn, noVDoc, noExt, useCustom, useShortName, mdefNamespaces,
             baseDir, sourcesToCopyMap, errorListener, schemasDir, cmdLineEntRes, classpath);
         if (errorListener.hasError()) {
             result = false;
@@ -693,6 +705,8 @@ public class SchemaCompiler {
             options.setCompilePartialMethod(partialMethods);
             options.setCompileNoAnnotations(noAnn);
             options.setCompileAnnotationAsJavadoc(copyAnn);
+            options.setCompileUseCustomEncoding(useCustom);
+            options.setCompileUseShortJavaName(useShortName);
 
             // save .xsb files
             system.save(filer);
@@ -722,7 +736,7 @@ public class SchemaCompiler {
                 if (javaFiles != null) {
                     sourcefiles.addAll(java.util.Arrays.asList(javaFiles));
                 }
-                if (!CodeGenUtil.externalCompile(sourcefiles, classesDir, classpath, debug, compiler, memoryInitialSize, memoryMaximumSize, quiet, verbose)) {
+                if (!CodeGenUtil.externalCompile(sourcefiles, classesDir, classpath, debug, compiler, memoryInitialSize, memoryMaximumSize, quiet, verbose, useCustom)) {
                     result = false;
                 }
 

--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
@@ -186,7 +186,7 @@ public class SchemaCompiler {
         boolean nojavac = (cl.getOpt("srconly") != null);
         boolean debug = (cl.getOpt("debug") != null);
         boolean copyAnn = (cl.getOpt("copyann") != null);
-        boolean useCustom = (cl.getOpt("usecustom") != null);
+        boolean sourceCodeEncoding = (cl.getOpt("sourcecodeencoding") != null);
         boolean useShortName = (cl.getOpt("useshortname") != null);
 
         String allowmdef = cl.getOpt("allowmdef");
@@ -335,7 +335,7 @@ public class SchemaCompiler {
         params.setNoVDoc(noVDoc);
         params.setNoExt(noExt);
         params.setDebug(debug);
-        params.setUseCustom(useCustom);
+        params.setSourceCodeEncoding(sourceCodeEncoding);
         params.setUseShortName(useShortName);
         params.setErrorListener(err);
         params.setRepackage(repackage);
@@ -360,7 +360,7 @@ public class SchemaCompiler {
 
     private static SchemaTypeSystem loadTypeSystem(String name, File[] xsdFiles, File[] wsdlFiles, URL[] urlFiles, File[] configFiles,
                                                    File[] javaFiles, ResourceLoader cpResourceLoader,
-                                                   boolean download, boolean noUpa, boolean noPvr, boolean noAnn, boolean noVDoc, boolean noExt, boolean useCustom, boolean useShortName,
+                                                   boolean download, boolean noUpa, boolean noPvr, boolean noAnn, boolean noVDoc, boolean noExt, boolean sourceCodeEncoding, boolean useShortName,
                                                    Set<String> mdefNamespaces, File baseDir, Map<String, String> sourcesToCopyMap,
                                                    Collection<XmlError> outerErrorListener, File schemasDir, EntityResolver entResolver, File[] classpath) {
         XmlErrorWatcher errorListener = new XmlErrorWatcher(outerErrorListener);
@@ -525,8 +525,8 @@ public class SchemaCompiler {
             if (noAnn) {
                 opts.setCompileNoAnnotations();
             }
-            if (useCustom) {
-                opts.setCompileUseCustomEncoding();
+            if (sourceCodeEncoding) {
+                opts.setCompileSourceCodeEncoding();
             }
             if (useShortName) {
                 opts.setCompileUseShortJavaName();
@@ -624,7 +624,7 @@ public class SchemaCompiler {
         boolean noExt = params.isNoExt();
         boolean incrSrcGen = params.isIncrementalSrcGen();
         boolean copyAnn = params.isCopyAnn();
-        boolean useCustom = params.isUseCustom();
+        boolean sourceCodeEncoding = params.isSourceCodeEncoding();
         boolean useShortName = params.isUseShortName();
         Collection<XmlError> outerErrorListener = params.getErrorListener();
         Set<BeanMethod> partialMethods = params.getPartialMethods();
@@ -678,7 +678,7 @@ public class SchemaCompiler {
         // build the in-memory type system
         XmlErrorWatcher errorListener = new XmlErrorWatcher(outerErrorListener);
         SchemaTypeSystem system = loadTypeSystem(name, xsdFiles, wsdlFiles, urlFiles, configFiles,
-            javaFiles, cpResourceLoader, download, noUpa, noPvr, noAnn, noVDoc, noExt, useCustom, useShortName, mdefNamespaces,
+            javaFiles, cpResourceLoader, download, noUpa, noPvr, noAnn, noVDoc, noExt, sourceCodeEncoding, useShortName, mdefNamespaces,
             baseDir, sourcesToCopyMap, errorListener, schemasDir, cmdLineEntRes, classpath);
         if (errorListener.hasError()) {
             result = false;
@@ -705,7 +705,7 @@ public class SchemaCompiler {
             options.setCompilePartialMethod(partialMethods);
             options.setCompileNoAnnotations(noAnn);
             options.setCompileAnnotationAsJavadoc(copyAnn);
-            options.setCompileUseCustomEncoding(useCustom);
+            options.setCompileSourceCodeEncoding(sourceCodeEncoding);
             options.setCompileUseShortJavaName(useShortName);
 
             // save .xsb files
@@ -736,7 +736,7 @@ public class SchemaCompiler {
                 if (javaFiles != null) {
                     sourcefiles.addAll(java.util.Arrays.asList(javaFiles));
                 }
-                if (!CodeGenUtil.externalCompile(sourcefiles, classesDir, classpath, debug, compiler, memoryInitialSize, memoryMaximumSize, quiet, verbose, useCustom)) {
+                if (!CodeGenUtil.externalCompile(sourcefiles, classesDir, classpath, debug, compiler, memoryInitialSize, memoryMaximumSize, quiet, verbose, sourceCodeEncoding)) {
                     result = false;
                 }
 

--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
@@ -67,7 +67,7 @@ public class SchemaCompiler {
         System.out.println("                              processed left-to-right, e.g. \"ALL,-GET_LIST\" exclude java.util.List getters - see XmlOptions.BeanMethod" );
         System.out.println("    -repackage - repackage specification, e.g. \"org.apache.xmlbeans.metadata:mypackage.metadata\" to change the metadata directory");
         System.out.println("    -copyann - copy schema annotations to javadoc (default false) - don't activate on untrusted schema sources!");
-        System.out.println("    -sourcecodeencoding - Generate Java source code and jar package using utf-8");
+        System.out.println("    -sourcecodeencoding [encodingName] - Generate Java source code and jar package by the encoding specified by encodingName");
         System.out.println("    -usejavashortname - Generate file name using JavaShortName");
         /* Undocumented feature - pass in one schema compiler extension and related parameters
         System.out.println("    -extension - registers a schema compiler extension");

--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
@@ -67,6 +67,8 @@ public class SchemaCompiler {
         System.out.println("                              processed left-to-right, e.g. \"ALL,-GET_LIST\" exclude java.util.List getters - see XmlOptions.BeanMethod" );
         System.out.println("    -repackage - repackage specification, e.g. \"org.apache.xmlbeans.metadata:mypackage.metadata\" to change the metadata directory");
         System.out.println("    -copyann - copy schema annotations to javadoc (default false) - don't activate on untrusted schema sources!");
+        System.out.println("    -sourcecodeencoding - Generate Java source code and jar package using utf-8");
+        System.out.println("    -usejavashortname - Generate file name using JavaShortName");
         /* Undocumented feature - pass in one schema compiler extension and related parameters
         System.out.println("    -extension - registers a schema compiler extension");
         System.out.println("    -extensionParms - specify parameters for the compiler extension");
@@ -98,6 +100,8 @@ public class SchemaCompiler {
         flags.add("noext");
         flags.add("srconly");
         flags.add("debug");
+        flags.add("sourcecodeencoding");
+        flags.add("usejavashortname");
 
         Set<String> opts = new HashSet<>();
         opts.add("out");

--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
@@ -186,8 +186,8 @@ public class SchemaCompiler {
         boolean nojavac = (cl.getOpt("srconly") != null);
         boolean debug = (cl.getOpt("debug") != null);
         boolean copyAnn = (cl.getOpt("copyann") != null);
-        boolean sourceCodeEncoding = (cl.getOpt("sourcecodeencoding") != null);
-        boolean useShortName = (cl.getOpt("useshortname") != null);
+        String sourceCodeEncoding = cl.getOpt("sourcecodeencoding");
+        boolean useJavaShortName = (cl.getOpt("usejavashortname") != null);
 
         String allowmdef = cl.getOpt("allowmdef");
         Set<String> mdefNamespaces = (allowmdef == null ? Collections.emptySet() :
@@ -336,7 +336,7 @@ public class SchemaCompiler {
         params.setNoExt(noExt);
         params.setDebug(debug);
         params.setSourceCodeEncoding(sourceCodeEncoding);
-        params.setUseShortName(useShortName);
+        params.setUseShortName(useJavaShortName);
         params.setErrorListener(err);
         params.setRepackage(repackage);
         params.setExtensions(extensions);
@@ -360,7 +360,7 @@ public class SchemaCompiler {
 
     private static SchemaTypeSystem loadTypeSystem(String name, File[] xsdFiles, File[] wsdlFiles, URL[] urlFiles, File[] configFiles,
                                                    File[] javaFiles, ResourceLoader cpResourceLoader,
-                                                   boolean download, boolean noUpa, boolean noPvr, boolean noAnn, boolean noVDoc, boolean noExt, boolean sourceCodeEncoding, boolean useShortName,
+                                                   boolean download, boolean noUpa, boolean noPvr, boolean noAnn, boolean noVDoc, boolean noExt, String sourceCodeEncoding, boolean useShortName,
                                                    Set<String> mdefNamespaces, File baseDir, Map<String, String> sourcesToCopyMap,
                                                    Collection<XmlError> outerErrorListener, File schemasDir, EntityResolver entResolver, File[] classpath) {
         XmlErrorWatcher errorListener = new XmlErrorWatcher(outerErrorListener);
@@ -525,8 +525,8 @@ public class SchemaCompiler {
             if (noAnn) {
                 opts.setCompileNoAnnotations();
             }
-            if (sourceCodeEncoding) {
-                opts.setCompileSourceCodeEncoding();
+            if (sourceCodeEncoding != null ) {
+                opts.setCharacterEncoding(sourceCodeEncoding);
             }
             if (useShortName) {
                 opts.setCompileUseShortJavaName();
@@ -624,7 +624,7 @@ public class SchemaCompiler {
         boolean noExt = params.isNoExt();
         boolean incrSrcGen = params.isIncrementalSrcGen();
         boolean copyAnn = params.isCopyAnn();
-        boolean sourceCodeEncoding = params.isSourceCodeEncoding();
+        String sourceCodeEncoding = params.getSourceCodeEncoding();
         boolean useShortName = params.isUseShortName();
         Collection<XmlError> outerErrorListener = params.getErrorListener();
         Set<BeanMethod> partialMethods = params.getPartialMethods();
@@ -705,7 +705,7 @@ public class SchemaCompiler {
             options.setCompilePartialMethod(partialMethods);
             options.setCompileNoAnnotations(noAnn);
             options.setCompileAnnotationAsJavadoc(copyAnn);
-            options.setCompileSourceCodeEncoding(sourceCodeEncoding);
+            options.setCharacterEncoding(sourceCodeEncoding);
             options.setCompileUseShortJavaName(useShortName);
 
             // save .xsb files
@@ -736,7 +736,8 @@ public class SchemaCompiler {
                 if (javaFiles != null) {
                     sourcefiles.addAll(java.util.Arrays.asList(javaFiles));
                 }
-                if (!CodeGenUtil.externalCompile(sourcefiles, classesDir, classpath, debug, compiler, memoryInitialSize, memoryMaximumSize, quiet, verbose, sourceCodeEncoding)) {
+                if (!CodeGenUtil.externalCompile(sourcefiles, classesDir, classpath, debug, compiler, null,
+                    memoryInitialSize, memoryMaximumSize, quiet, verbose, sourceCodeEncoding)) {
                     result = false;
                 }
 

--- a/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
+++ b/src/main/java/org/apache/xmlbeans/impl/tool/SchemaCompiler.java
@@ -100,13 +100,13 @@ public class SchemaCompiler {
         flags.add("noext");
         flags.add("srconly");
         flags.add("debug");
-        flags.add("sourcecodeencoding");
         flags.add("usejavashortname");
 
         Set<String> opts = new HashSet<>();
         opts.add("out");
         opts.add("name");
         opts.add("src");
+        opts.add("sourcecodeencoding");
         opts.add("d");
         opts.add("cp");
         opts.add("compiler");

--- a/src/main/java/org/apache/xmlbeans/impl/util/FilerImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/FilerImpl.java
@@ -85,10 +85,10 @@ public class FilerImpl implements Filer {
      * Creates a new binding source file (.java) and returns a writer for it.
      *
      * @param typename fully qualified type name
-     * @param useCustomEncoding whether use CustomEncoding
+     * @param sourceCodeEncoding whether use CustomEncoding
      * @return a stream to write the type to
      */
-    public Writer createSourceFile(String typename, boolean useCustomEncoding) throws IOException {
+    public Writer createSourceFile(String typename, boolean sourceCodeEncoding) throws IOException {
         if (incrSrcGen) {
             seenTypes.add(typename);
         }
@@ -115,7 +115,7 @@ public class FilerImpl implements Filer {
             return new IncrFileWriter(sourcefile, repackager);
         } else {
             return repackager == null ?
-                writerForFile(sourcefile, useCustomEncoding) :
+                writerForFile(sourcefile, sourceCodeEncoding) :
                 new RepackagingWriter(sourcefile, repackager);
         }
     }
@@ -128,9 +128,9 @@ public class FilerImpl implements Filer {
         return repackager;
     }
 
-    private static Writer writerForFile(File f, boolean useCustomEncoding) throws IOException {
+    private static Writer writerForFile(File f, boolean sourceCodeEncoding) throws IOException {
         if (CHARSET == null) {
-            return Files.newBufferedWriter(f.toPath(), useCustomEncoding ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1);
+            return Files.newBufferedWriter(f.toPath(), sourceCodeEncoding ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1);
         }
 
         FileOutputStream fileStream = new FileOutputStream(f);

--- a/src/main/java/org/apache/xmlbeans/impl/util/FilerImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/FilerImpl.java
@@ -85,9 +85,10 @@ public class FilerImpl implements Filer {
      * Creates a new binding source file (.java) and returns a writer for it.
      *
      * @param typename fully qualified type name
+     * @param useCustomEncoding whether use CustomEncoding
      * @return a stream to write the type to
      */
-    public Writer createSourceFile(String typename) throws IOException {
+    public Writer createSourceFile(String typename, boolean useCustomEncoding) throws IOException {
         if (incrSrcGen) {
             seenTypes.add(typename);
         }
@@ -114,7 +115,7 @@ public class FilerImpl implements Filer {
             return new IncrFileWriter(sourcefile, repackager);
         } else {
             return repackager == null ?
-                writerForFile(sourcefile) :
+                writerForFile(sourcefile, useCustomEncoding) :
                 new RepackagingWriter(sourcefile, repackager);
         }
     }
@@ -127,9 +128,9 @@ public class FilerImpl implements Filer {
         return repackager;
     }
 
-    private static Writer writerForFile(File f) throws IOException {
+    private static Writer writerForFile(File f, boolean useCustomEncoding) throws IOException {
         if (CHARSET == null) {
-            return Files.newBufferedWriter(f.toPath(), StandardCharsets.ISO_8859_1);
+            return Files.newBufferedWriter(f.toPath(), useCustomEncoding ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1);
         }
 
         FileOutputStream fileStream = new FileOutputStream(f);
@@ -164,7 +165,7 @@ public class FilerImpl implements Filer {
 
             if (diffs.size() > 0) {
                 // Diffs encountered, replace the file on disk with text from the buffer
-                try (Writer fw = writerForFile(_file)) {
+                try (Writer fw = writerForFile(_file, false)) {
                     fw.write(str);
                 }
             }
@@ -180,7 +181,7 @@ public class FilerImpl implements Filer {
         public void close() throws IOException {
             super.close();
 
-            try (Writer fw = writerForFile(_file)) {
+            try (Writer fw = writerForFile(_file, false)) {
                 fw.write(_repackager.repackage(getBuffer()).toString());
             }
         }

--- a/src/main/java/org/apache/xmlbeans/impl/values/XmlObjectBase.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/XmlObjectBase.java
@@ -35,6 +35,7 @@ import java.math.BigInteger;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.zip.ZipOutputStream;
 
 public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlObject, SimpleValue {
     public static final short MAJOR_VERSION_NUMBER = (short) 1; // for serialization
@@ -191,6 +192,12 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
         }
     }
 
+    public void save(ZipOutputStream zos, XmlOptions options) throws IOException {
+        try (XmlCursor cur = newCursorForce()) {
+            cur.save(zos, makeInnerOptions(options));
+        }
+    }
+
     public void save(Writer w, XmlOptions options) throws IOException {
         try (XmlCursor cur = newCursorForce()) {
             cur.save(w, makeInnerOptions(options));
@@ -207,6 +214,10 @@ public abstract class XmlObjectBase implements TypeStoreUser, Serializable, XmlO
 
     public void save(OutputStream os) throws IOException {
         save(os, null);
+    }
+
+    public void save(ZipOutputStream zos) throws IOException {
+        save(zos, null);
     }
 
     public void save(Writer w) throws IOException {

--- a/src/test/java/compile/scomp/checkin/XmlBeansCompCheckinTests.java
+++ b/src/test/java/compile/scomp/checkin/XmlBeansCompCheckinTests.java
@@ -36,6 +36,7 @@ public class XmlBeansCompCheckinTests {
     private final List<XmlError> xm_errors = new ArrayList<>();
     private final XmlOptions xm_opts = new XmlOptions();
     private final List<String> expBinType;
+    private final List<String> expBinShortnameType;
     private final List<String> expSrcType;
 
     public XmlBeansCompCheckinTests() {
@@ -48,6 +49,18 @@ public class XmlBeansCompCheckinTests {
             "org/apache/xmlbeans/metadata/type/http_3A_2F_2Fbaz/aType.xsb",
             "org/apache/xmlbeans/metadata/namespace/http_3A_2F_2Fbaz/xmlns.xsb",
             "org/apache/xmlbeans/metadata/javaname/baz/ElNameDocument.xsb",
+            "org/apache/xmlbeans/metadata/javaname/baz/AType.xsb"
+        );
+
+        expBinShortnameType = Arrays.asList(
+            "org/apache/xmlbeans/metadata/system/apiCompile/atypedb57type.xsb", 
+            "org/apache/xmlbeans/metadata/system/apiCompile/elnamedocument429edoctype.xsb", 
+            "org/apache/xmlbeans/metadata/system/apiCompile/atypeelement.xsb", 
+            "org/apache/xmlbeans/metadata/system/apiCompile/index.xsb", 
+            "org/apache/xmlbeans/metadata/element/http_3A_2F_2Fbaz/atypeelement.xsb", 
+            "org/apache/xmlbeans/metadata/type/http_3A_2F_2Fbaz/atypedb57type.xsb", 
+            "org/apache/xmlbeans/metadata/namespace/http_3A_2F_2Fbaz/xmlns.xsb",
+            "org/apache/xmlbeans/metadata/javaname/baz/ElNameDocument.xsb", 
             "org/apache/xmlbeans/metadata/javaname/baz/AType.xsb"
         );
 
@@ -83,6 +96,25 @@ public class XmlBeansCompCheckinTests {
 
         assertNotNull(f.getBinFileVec());
         MatcherAssert.assertThat(f.getBinFileVec(), is(expBinType));
+
+        assertNotNull(f.getSrcFileVec());
+        MatcherAssert.assertThat(f.getSrcFileVec(), is(expSrcType));
+    }
+
+    @Test
+    void test_Filer_shortname_compilation() throws Exception {
+        XmlObject obj1 = XmlObject.Factory.parse(FOR_XSD);
+        XmlObject[] schemas = new XmlObject[]{obj1};
+
+        TestFiler f = new TestFiler();
+        xm_opts.setCompileUseShortJavaName();
+        XmlBeans.compileXmlBeans("apiCompile", null, schemas, null, XmlBeans.getBuiltinTypeSystem(), f, xm_opts);
+
+        assertTrue(f.isCreateBinaryFile(), "Binary File method not invoked");
+        assertTrue(f.isCreateSourceFile(), "Source File method not invoked");
+
+        assertNotNull(f.getBinFileVec());
+        MatcherAssert.assertThat(f.getBinFileVec(), is(expBinShortnameType));
 
         assertNotNull(f.getSrcFileVec());
         MatcherAssert.assertThat(f.getSrcFileVec(), is(expSrcType));

--- a/src/test/java/compile/scomp/common/mockobj/TestFiler.java
+++ b/src/test/java/compile/scomp/common/mockobj/TestFiler.java
@@ -51,7 +51,13 @@ public class TestFiler implements Filer {
     public Writer createSourceFile(String typename) throws IOException {
         srcFileVec.add(typename);
         isCreateSourceFile = true;
-        return impl.createSourceFile(typename);
+        return impl.createSourceFile(typename, false);
+    }
+
+    public Writer createSourceFile(String typename, boolean useCustom) throws IOException {
+        srcFileVec.add(typename);
+        isCreateSourceFile = true;
+        return impl.createSourceFile(typename, useCustom);
     }
 
     public boolean isCreateBinaryFile() {

--- a/src/test/java/compile/scomp/common/mockobj/TestFiler.java
+++ b/src/test/java/compile/scomp/common/mockobj/TestFiler.java
@@ -48,13 +48,7 @@ public class TestFiler implements Filer {
         return impl.createBinaryFile(typename);
     }
 
-    public Writer createSourceFile(String typename) throws IOException {
-        srcFileVec.add(typename);
-        isCreateSourceFile = true;
-        return impl.createSourceFile(typename, false);
-    }
-
-    public Writer createSourceFile(String typename, boolean sourceCodeEncoding) throws IOException {
+    public Writer createSourceFile(String typename, String sourceCodeEncoding) throws IOException {
         srcFileVec.add(typename);
         isCreateSourceFile = true;
         return impl.createSourceFile(typename, sourceCodeEncoding);

--- a/src/test/java/compile/scomp/common/mockobj/TestFiler.java
+++ b/src/test/java/compile/scomp/common/mockobj/TestFiler.java
@@ -54,10 +54,10 @@ public class TestFiler implements Filer {
         return impl.createSourceFile(typename, false);
     }
 
-    public Writer createSourceFile(String typename, boolean useCustom) throws IOException {
+    public Writer createSourceFile(String typename, boolean sourceCodeEncoding) throws IOException {
         srcFileVec.add(typename);
         isCreateSourceFile = true;
-        return impl.createSourceFile(typename, useCustom);
+        return impl.createSourceFile(typename, sourceCodeEncoding);
     }
 
     public boolean isCreateBinaryFile() {

--- a/src/test/java/xmlobject/detailed/XmlObjectAbstractClassTest.java
+++ b/src/test/java/xmlobject/detailed/XmlObjectAbstractClassTest.java
@@ -57,7 +57,7 @@ public class XmlObjectAbstractClassTest {
 
         return CodeGenUtil.externalCompile(srcFiles, dir, classpath, false,
             CodeGenUtil.DEFAULT_COMPILER, null, CodeGenUtil.DEFAULT_MEM_START,
-            CodeGenUtil.DEFAULT_MEM_MAX, false, false);
+            CodeGenUtil.DEFAULT_MEM_MAX, false, false, false);
     }
 
     /**

--- a/src/test/java/xmlobject/detailed/XmlObjectAbstractClassTest.java
+++ b/src/test/java/xmlobject/detailed/XmlObjectAbstractClassTest.java
@@ -57,7 +57,7 @@ public class XmlObjectAbstractClassTest {
 
         return CodeGenUtil.externalCompile(srcFiles, dir, classpath, false,
             CodeGenUtil.DEFAULT_COMPILER, null, CodeGenUtil.DEFAULT_MEM_START,
-            CodeGenUtil.DEFAULT_MEM_MAX, false, false, false);
+            CodeGenUtil.DEFAULT_MEM_MAX, false, false, null);
     }
 
     /**


### PR DESCRIPTION
[Reason: xmlbeans-REL_5_1_1 does not support Chinese paths (essentially, javac on the win platform does not support Chinese source code paths)]

1.Add two command line parameters to control whether to use the new encoding method to generate Java source code and build the JAR package. 
2.Add properties in the options to support the above changes. 
3.During compilation, select different generation logic by checking whether the "usecustom" and "useshortname" parameters are present. 
4.Add in-code unit tests for verification.