### PR TITLE
Id attribute causes index oob

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/Cur.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Cur.java
@@ -2923,10 +2923,12 @@ public final class Cur {
             text(value, 0, value.length());
             end();
             if (isId) {
+                _locale.enter();
                 Cur c1 = x.tempCur();
                 c1.toRoot();
                 Xobj doc = c1._xobj;
                 c1.release();
+                _locale.exit();
                 if (doc instanceof DocumentXobj) {
                     ((DocumentXobj) doc).addIdElement(value,
                         x._parent.getDom());

--- a/src/test/java/xmlcursor/checkin/StoreTests.java
+++ b/src/test/java/xmlcursor/checkin/StoreTests.java
@@ -15,7 +15,6 @@
 
 package xmlcursor.checkin;
 
-import com.sun.org.apache.xml.internal.serializer.AttributesImplSerializer;
 import org.apache.xmlbeans.*;
 import org.apache.xmlbeans.XmlCursor.TokenType;
 import org.apache.xmlbeans.XmlCursor.XmlBookmark;
@@ -28,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.xml.sax.*;
 import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.AttributesImpl;
 import xmlcursor.common.Common;
 
 import javax.xml.namespace.QName;
@@ -1958,7 +1958,7 @@ public class StoreTests {
         final String schemaUri = "http://example.com/schema";
 
         final Locale loc = Locale.getLocale(null, null);
-        final AttributesImplSerializer attrs = new AttributesImplSerializer();
+        final AttributesImpl attrs = new AttributesImpl();
 
         // The QName must be "id" as that's now enough for an attribute to be treated as an ID
         attrs.addAttribute(

--- a/src/test/java/xmlcursor/checkin/StoreTests.java
+++ b/src/test/java/xmlcursor/checkin/StoreTests.java
@@ -15,9 +15,11 @@
 
 package xmlcursor.checkin;
 
+import com.sun.org.apache.xml.internal.serializer.AttributesImplSerializer;
 import org.apache.xmlbeans.*;
 import org.apache.xmlbeans.XmlCursor.TokenType;
 import org.apache.xmlbeans.XmlCursor.XmlBookmark;
+import org.apache.xmlbeans.impl.store.Locale;
 import org.apache.xmlbeans.impl.xb.xsdschema.SchemaDocument;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -1948,6 +1950,38 @@ public class StoreTests {
         XmlObject x2 = XmlObject.Factory.parse(xml);
 
         assertEquals(x1.xmlText(), x2.xmlText());
+    }
+
+    @Test
+    void testSaxHandlerIdDetection() throws SAXException{
+        final XmlOptions emptyXmlOptions = new XmlOptions();
+        final String schemaUri = "http://example.com/schema";
+
+        final Locale loc = Locale.getLocale(null, null);
+        final AttributesImplSerializer attrs = new AttributesImplSerializer();
+
+        // The QName must be "id" as that's now enough for an attribute to be treated as an ID
+        attrs.addAttribute(
+                schemaUri,
+                "localIgnored",
+                "id",
+                "CDATA",
+                "anId"
+        );
+
+        loc.getSchemaTypeLoader().newXmlSaxHandler(null, emptyXmlOptions);
+        ContentHandler xmlSaxHandler = Locale.newSaxHandler(
+                loc.getSchemaTypeLoader(),
+                null,
+                emptyXmlOptions
+        ).getContentHandler();
+
+        xmlSaxHandler.startElement(
+                schemaUri,
+                "localIgnored",
+                "sa:someName",
+                attrs
+        );
     }
 
     @Test


### PR DESCRIPTION
When a Cur detects an ID attribute it fails to `enter()` it's locale before generating a `tempCur()`, leading to an index out of bounds exception from `Locale:1934` when attempting to get the next available `tempFrame`.