### PR TITLE
imports of schemas - path with backslash and compile options

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/StscImporter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/StscImporter.java
@@ -225,7 +225,7 @@ public class StscImporter {
     //workaround for Sun bug # 4723726
     public static URI resolve(URI base, String child)
         throws URISyntaxException {
-        URI childUri = new URI(child);
+        URI childUri = new URI(child.replace('\\', '/'));
         URI ruri = base.resolve(childUri);
 
         // if the child fragment is relative (which we'll assume is the case
@@ -502,6 +502,9 @@ public class StscImporter {
                         XmlOptions options = new XmlOptions();
                         options.setLoadLineNumbers();
                         options.setDocumentSourceName(absoluteURL);
+                        options.setCompileNoAnnotations(state.noAnn());
+                        options.setCompileNoPvrRule(state.noPvr());
+                        options.setCompileNoPvrRule(state.noUpa());
                         return loader.parse(reader, null, options);
                     }
 


### PR DESCRIPTION
1) path with backslash in  schemaLocation of <xsd:import> is valid path. 
for example
	<xs:import namespace="urn:hl7-org:v3" schemaLocation="coreschemas\datatypes-base.xsd"/>

2) xsd which was imported should be compiled with the same values of options as main xsd