### PR TITLE
Fall back to SHA-1 for base64/binary hashCode

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/values/JavaBase64Holder.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/JavaBase64Holder.java
@@ -23,17 +23,13 @@ import org.apache.xmlbeans.impl.common.QNameHelper;
 import org.apache.xmlbeans.impl.common.ValidationContext;
 import org.apache.xmlbeans.impl.schema.BuiltinSchemaTypeSystem;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 
-public abstract class JavaBase64Holder extends XmlObjectBase {
+public abstract class JavaBase64Holder extends JavaDigestableHolder {
     public SchemaType schemaType() {
         return BuiltinSchemaTypeSystem.ST_BASE_64_BINARY;
     }
-
-    protected byte[] _value;
 
     // SIMPLE VALUE ACCESSORS BELOW -------------------------------------------
 
@@ -103,33 +99,5 @@ public abstract class JavaBase64Holder extends XmlObjectBase {
     protected boolean equal_to(XmlObject i) {
         byte[] ival = ((XmlBase64Binary) i).getByteArrayValue();
         return Arrays.equals(_value, ival);
-    }
-
-    //because computing hashcode is expensive we'll cache it
-    protected boolean _hashcached = false;
-    protected int hashcode = 0;
-    protected static final MessageDigest md5;
-
-    static {
-        try {
-            md5 = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Cannot find MD5 hash Algorithm");
-        }
-    }
-
-    protected int value_hash_code() {
-        if (_hashcached) {
-            return hashcode;
-        }
-
-        _hashcached = true;
-
-        if (_value == null) {
-            return hashcode = 0;
-        }
-
-        byte[] res = md5.digest(_value);
-        return hashcode = (res[0] << 24) | (res[1] << 16) | (res[2] << 8) | res[3];
     }
 }

--- a/src/main/java/org/apache/xmlbeans/impl/values/JavaDigestableHolder.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/JavaDigestableHolder.java
@@ -1,0 +1,60 @@
+/*   Copyright 2004 The Apache Software Foundation
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.xmlbeans.impl.values;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public abstract class JavaDigestableHolder extends XmlObjectBase {
+    protected byte[] _value;
+
+    //because computing hashcode is expensive we'll cache it
+    protected boolean _hashcached = false;
+    protected int hashcode = 0;
+    protected static final MessageDigest digest;
+
+    static {
+        digest = Stream.of("MD5", "SHA-1")
+            .map(algorithm -> {
+                try {
+                    return MessageDigest.getInstance(algorithm);
+                }
+                catch (NoSuchAlgorithmException ex) {
+                    return null;
+                }
+            })
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Cannot find any suitable hash algorithm"));
+    }
+
+    protected int value_hash_code() {
+        if (_hashcached) {
+            return hashcode;
+        }
+
+        _hashcached = true;
+
+        if (_value == null) {
+            return hashcode = 0;
+        }
+
+        byte[] res = digest.digest(_value);
+        return hashcode = (res[0] << 24) | (res[1] << 16) | (res[2] << 8) | res[3];
+    }
+}

--- a/src/main/java/org/apache/xmlbeans/impl/values/JavaHexBinaryHolder.java
+++ b/src/main/java/org/apache/xmlbeans/impl/values/JavaHexBinaryHolder.java
@@ -25,16 +25,12 @@ import org.apache.xmlbeans.impl.schema.BuiltinSchemaTypeSystem;
 import org.apache.xmlbeans.impl.util.HexBin;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
-public abstract class JavaHexBinaryHolder extends XmlObjectBase {
+public abstract class JavaHexBinaryHolder extends JavaDigestableHolder {
     public SchemaType schemaType() {
         return BuiltinSchemaTypeSystem.ST_HEX_BINARY;
     }
-
-    protected byte[] _value;
 
     // SIMPLE VALUE ACCESSORS BELOW -------------------------------------------
 
@@ -107,33 +103,4 @@ public abstract class JavaHexBinaryHolder extends XmlObjectBase {
         byte[] ival = ((XmlHexBinary) i).getByteArrayValue();
         return Arrays.equals(_value, ival);
     }
-
-    //because computing hashcode is expensive we'll cache it
-    protected boolean _hashcached = false;
-    protected int hashcode = 0;
-    protected static final MessageDigest md5;
-
-    static {
-        try {
-            md5 = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Cannot find MD5 hash Algorithm");
-        }
-    }
-
-    protected int value_hash_code() {
-        if (_hashcached) {
-            return hashcode;
-        }
-
-        _hashcached = true;
-
-        if (_value == null) {
-            return hashcode = 0;
-        }
-
-        byte[] res = md5.digest(_value);
-        return hashcode = (res[0] << 24) | (res[1] << 16) | (res[2] << 8) | res[3];
-    }
-
 }


### PR DESCRIPTION
MD5 digest algorithm is unavailable on a FIPS JVM, so fall back to SHA-1 for generating object hashCodes in this case.  Only the first 32 bits are used, so the length difference will not matter.