### PR TITLE
Update log4j to 2.25.3 to address CVE-2025-68161

### DIFF
--- a/LICENSE-binary.txt
+++ b/LICENSE-binary.txt
@@ -211,7 +211,7 @@ org.apache.ant:ant-launcher:1.10.15
 org.apache.httpcomponents.client5:httpclient5:5.1.3
 org.apache.httpcomponents.client5:httpcore5:5.1.3
 org.apache.httpcomponents.client5:httpcore5-h2:5.1.3
-org.apache.logging.log4j:log4j-api:2.24.3
+org.apache.logging.log4j:log4j-api:2.25.3
 org.xmlresolver:xmlresolver:5.2.2
 org.xmlresolver:xmlresolver-data:5.2.2
 

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ configurations {
 ext {
     antVersion = '1.10.15'
     javaparserVersion = '3.27.1'
-    log4jVersion = '2.24.3'
+    log4jVersion = '2.25.3'
     saxonVersion = '12.9'
     androidSdkMinimum = '26'
     jdkVersion = (project.properties['jdkVersion'] ?: '8') as int

--- a/build.xml
+++ b/build.xml
@@ -120,7 +120,7 @@
 
     <!-- dependencies -->
     <dependency prefix="xml-apis" artifact="xml-apis:xml-apis:1.4.01" usage="java8"/>
-    <dependency prefix="log4j-api" artifact="org.apache.logging.log4j:log4j-api:2.24.3" usage="main"/>
+    <dependency prefix="log4j-api" artifact="org.apache.logging.log4j:log4j-api:2.25.3" usage="main"/>
     <dependency prefix="saxon" artifact="net.sf.saxon:Saxon-HE:12.9" usage="main"/>
     <dependency prefix="ant" artifact="org.apache.ant:ant:1.10.15" usage="main"/>
     <dependency prefix="javaparser-core" artifact="com.github.javaparser:javaparser-core:3.27.1" usage="main"/>
@@ -140,7 +140,7 @@
 
     <!-- test dependencies -->
     <dependency prefix="junit" artifact="junit:junit:4.13.2" usage="tests"/>
-    <dependency prefix="log4j-core" artifact="org.apache.logging.log4j:log4j-core:2.24.3" usage="tests"/>
+    <dependency prefix="log4j-core" artifact="org.apache.logging.log4j:log4j-core:2.25.3" usage="tests"/>
     <dependency prefix="xmlresolver" artifact="org.xmlresolver:xmlresolver:5.2.5" usage="main"/>
     <dependency prefix="ant-junit" artifact="org.apache.ant:ant-junit:1.10.15" usage="tests"/>
     <dependency prefix="ant-junit4" artifact="org.apache.ant:ant-junit4:1.10.15" usage="tests"/>
@@ -928,9 +928,9 @@
         <dependency prefix="spotbugs.commons-text" artifact="org.apache.commons:commons-text:1.9" usage="${spotbugs.lib}"/>
         <dependency prefix="spotbugs.jcip-annotations" artifact="net.jcip:jcip-annotations:1.0" usage="${spotbugs.lib}"/>
         <dependency prefix="spotbugs.icu4j" artifact="com.ibm.icu:icu4j:68.2" usage="${spotbugs.lib}" target="icu4j-63.1.jar"/>
-        <dependency prefix="spotbugs.log4j-api" artifact="org.apache.logging.log4j:log4j-api:2.24.3" usage="${spotbugs.lib}"/>
-        <dependency prefix="spotbugs.log4j-core" artifact="org.apache.logging.log4j:log4j-core:2.24.3" usage="${spotbugs.lib}"/>
-        <dependency prefix="spotbugs.log4j-slf4j18-impl" artifact="org.apache.logging.log4j:log4j-slf4j18-impl:2.24.3" usage="${spotbugs.lib}"/>
+        <dependency prefix="spotbugs.log4j-api" artifact="org.apache.logging.log4j:log4j-api:2.25.3" usage="${spotbugs.lib}"/>
+        <dependency prefix="spotbugs.log4j-core" artifact="org.apache.logging.log4j:log4j-core:2.25.3" usage="${spotbugs.lib}"/>
+        <dependency prefix="spotbugs.log4j-slf4j18-impl" artifact="org.apache.logging.log4j:log4j-slf4j18-impl:2.25.3" usage="${spotbugs.lib}"/>
         <dependency prefix="spotbugs.saxon" artifact="net.sf.saxon:Saxon-HE:9.9.1-8" usage="${spotbugs.lib}"/>
 
         <mkdir dir="${basedir}${spotbugs.lib}/config"/>

--- a/src/main/maven/org.apache.xmlbeans/xmlbeans/pom.xml
+++ b/src/main/maven/org.apache.xmlbeans/xmlbeans/pom.xml
@@ -81,7 +81,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.24.3</version>
+                <version>2.25.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/maven/plugin.xml
+++ b/src/main/maven/plugin.xml
@@ -407,12 +407,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.24.3</version>
+            <version>2.25.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.24.3</version>
+            <version>2.25.3</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>


### PR DESCRIPTION
It'd be exceptionally unlikely to be hit, but this will clear the CVE from this project. See [CVE-2025-68161](https://nvd.nist.gov/vuln/detail/CVE-2025-68161) for details.