### PR TITLE
CommentXobj shouldn't have child nodes

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/CommentXobj.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/CommentXobj.java
@@ -54,6 +54,10 @@ class CommentXobj extends NodeXobj implements Comment {
         return null;
     }
 
+    public Node getLastChild() {
+        return null;
+    }
+
     public boolean hasChildNodes() {
         return false;
     }

--- a/src/main/java/org/apache/xmlbeans/impl/store/CommentXobj.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/CommentXobj.java
@@ -54,6 +54,10 @@ class CommentXobj extends NodeXobj implements Comment {
         return null;
     }
 
+    public boolean hasChildNodes() {
+        return false;
+    }
+
     public void insertData(int offset, String arg) {
         DomImpl._characterData_insertData(this, offset, arg);
     }


### PR DESCRIPTION
Hello

Current version has an issue, when xml contains comment followed by a whitespace character. This leads to situation, when after first iteration of xpath selection the `hasChildNodes()` method returns `true` for `CommentXobj` instance. With that next usages of `selectPath(...)` return incorrect result.

Please see code below for reproduction:

```
        XmlObject xmlObject = XmlObject.Factory.parse("<outerTag><!-- comment with whitespace after it --> <innerTag>textToFind1</innerTag><innerTag>textToFind2</innerTag></outerTag>");
        String xpath = "//innerTag";

        System.out.println(Arrays.stream(xmlObject.selectPath(xpath)).toList().size()); // prints 2
        System.out.println(Arrays.stream(xmlObject.selectPath(xpath)).toList().size()); // prints 0
```