### PR TITLE
reject non-ascii digits when lexing xsd integer types

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
@@ -619,7 +619,7 @@ public final class XsTypeConverter {
 
         for (int i = 0; i < length - start; i++) {
             c = ch.charAt(i + start);
-            int v = Character.digit(c, 10);
+            int v = (c >= '0' && c <= '9') ? c - '0' : -1;
 
             if (v < 0) {
                 throw new NumberFormatException("For input string: \"" + ch.toString() + "\"");

--- a/src/test/java/misc/checkin/XsTypeConverterTest.java
+++ b/src/test/java/misc/checkin/XsTypeConverterTest.java
@@ -1,0 +1,59 @@
+/*   Copyright 2004 The Apache Software Foundation
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package misc.checkin;
+
+import org.apache.xmlbeans.impl.util.XsTypeConverter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class XsTypeConverterTest {
+
+    // fullwidth "123", arabic-indic "123" and devanagari "123" are unicode
+    // decimal digits but outside the xsd lexical space.
+    private static final String FULLWIDTH_123 = "１２３";
+    private static final String ARABIC_123 = "١٢٣";
+    private static final String DEVANAGARI_123 = "१२३";
+
+    @Test
+    void lexIntAcceptsAscii() {
+        assertEquals(123, XsTypeConverter.lexInt("123"));
+        assertEquals(-123, XsTypeConverter.lexInt("-123"));
+        assertEquals(123, XsTypeConverter.lexInt("+123"));
+    }
+
+    @Test
+    void lexIntRejectsNonAsciiDigits() {
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexInt(FULLWIDTH_123));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexInt(ARABIC_123));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexInt(DEVANAGARI_123));
+    }
+
+    @Test
+    void lexShortRejectsNonAsciiDigits() {
+        assertEquals(123, XsTypeConverter.lexShort("123"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexShort(FULLWIDTH_123));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexShort(ARABIC_123));
+    }
+
+    @Test
+    void lexByteRejectsNonAsciiDigits() {
+        assertEquals(123, XsTypeConverter.lexByte("123"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexByte(FULLWIDTH_123));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexByte(ARABIC_123));
+    }
+}


### PR DESCRIPTION
Noticed while feeding random unicode into lexInt: parseIntXsdNumber uses Character.digit(c, 10), which maps any unicode decimal digit (fullwidth U+FF11, arabic-indic U+0661, devanagari, ...) to a value, so "１２３" parses to 123 as a valid xsd:int/short/byte. Those code points are outside the xsd lexical space and lexLong/lexInteger already reject them via Long.parseLong/BigInteger. Restrict the digit check to ascii 0-9.