### PR TITLE
fix out-of-bounds read in HexBin for byte 0xff

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/HexBin.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/HexBin.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
  * </p>
  */
 public final class HexBin {
-    static private final int BASELENGTH = 255;
+    static private final int BASELENGTH = 256;
     static private final int LOOKUPLENGTH = 16;
     static private final byte[] hexNumberTable = new byte[BASELENGTH];
     static private final byte[] lookUpHexAlphabet = new byte[LOOKUPLENGTH];

--- a/src/test/java/misc/checkin/HexBinTest.java
+++ b/src/test/java/misc/checkin/HexBinTest.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class HexBinTest {
 
@@ -34,6 +35,15 @@ public class HexBinTest {
         String enc = HexBin.encode(exp);
         String dec = HexBin.decode(enc);
         assertEquals(exp, dec);
+    }
+
+    @Test
+    void testInvalidHighByte() {
+        // 0xFF is not a hex digit; decode must report it like any other invalid
+        // input (null) instead of indexing past the lookup table.
+        assertNull(HexBin.decode(new byte[]{(byte) 0xFF, (byte) 0xFF}));
+        assertNull(HexBin.decode(new String(new byte[]{(byte) 0xFF, (byte) 0xFF},
+            StandardCharsets.ISO_8859_1)));
     }
 
     @Test


### PR DESCRIPTION
isHex looks up hexNumberTable[octet & 0xFF] so the index can be 255, but the table is sized 255 (max index 254), so a 0xFF byte (a U+00FF char in xsd:hexBinary text) makes decode throw ArrayIndexOutOfBoundsException instead of returning null for non-hex input like it does for every other invalid byte. Sizing the table to 256 keeps the check inside the lookup table.