### PR TITLE
Reject lone trailing f/F in lexFloat instead of indexing out of bounds

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
@@ -51,7 +51,7 @@ public final class XsTypeConverter {
             if (cs.length() > 0) {
                 char ch = cs.charAt(cs.length() - 1);
                 if (ch == 'f' || ch == 'F') {
-                    if (cs.charAt(cs.length() - 2) != 'N') {
+                    if (cs.length() < 2 || cs.charAt(cs.length() - 2) != 'N') {
                         throw new NumberFormatException("Invalid char '" + ch + "' in float.");
                     }
                 }

--- a/src/test/java/misc/checkin/XsTypeConverterTest.java
+++ b/src/test/java/misc/checkin/XsTypeConverterTest.java
@@ -55,4 +55,20 @@ public class XsTypeConverterTest {
         assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexByte(FULLWIDTH_123));
         assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexByte(ARABIC_123));
     }
+
+    @Test
+    void lexFloatRejectsLoneTrailingF() {
+        // a single "f"/"F" used to read charAt(length - 2) and throw
+        // StringIndexOutOfBoundsException instead of NumberFormatException
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexFloat("f"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexFloat("F"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexFloat("1.0f"));
+    }
+
+    @Test
+    void lexFloatAcceptsValidValues() {
+        assertEquals(1.5f, XsTypeConverter.lexFloat("1.5"));
+        assertEquals(Float.POSITIVE_INFINITY, XsTypeConverter.lexFloat("INF"));
+        assertEquals(Float.NEGATIVE_INFINITY, XsTypeConverter.lexFloat("-INF"));
+    }
 }


### PR DESCRIPTION
Spotted while reading the float lexer. When the last character is f or F, lexFloat looks back one character to let INF fall through to the infinity handler:

    StringIndexOutOfBoundsException: Index -1 out of bounds for length 1
        at java.base/java.lang.String.charAt
        at XsTypeConverter.lexFloat(XsTypeConverter.java:54)

For an input of just "f" or "F" the lookback is charAt(-1), so it throws StringIndexOutOfBoundsException. JavaFloatHolder.validateLexical only catches NumberFormatException, so this leaks out as an unexpected runtime exception when validating untrusted xsd:float text rather than being reported as an invalid value.

Guard the lookback with a length check so a lone f/F is rejected the same way as 1.0f. INF/-INF still parse. Tests added.