### PR TITLE
Fix out-of-bounds read in lexFloat for single-character input

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
@@ -48,12 +48,10 @@ public final class XsTypeConverter {
             //current jdk impl of parseFloat calls trim() on the string.
             //Any other space is illegal anyway, whether there are one or more spaces.
             //so no need to do a collapse pass through the string.
-            if (cs.length() > 0) {
+            if (cs.length() > 1) {
                 char ch = cs.charAt(cs.length() - 1);
-                if (ch == 'f' || ch == 'F') {
-                    if (cs.charAt(cs.length() - 2) != 'N') {
-                        throw new NumberFormatException("Invalid char '" + ch + "' in float.");
-                    }
+                if ((ch == 'f' || ch == 'F') && cs.charAt(cs.length() - 2) != 'N') {
+                    throw new NumberFormatException("Invalid char '" + ch + "' in float.");
                 }
             }
             return Float.parseFloat(v);

--- a/src/test/java/misc/checkin/XsTypeConverterTest.java
+++ b/src/test/java/misc/checkin/XsTypeConverterTest.java
@@ -55,4 +55,25 @@ public class XsTypeConverterTest {
         assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexByte(FULLWIDTH_123));
         assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexByte(ARABIC_123));
     }
+
+    @Test
+    void lexFloatRejectsSingleCharSuffix() {
+        // a lone "f"/"F" used to read charAt(-1) and throw
+        // StringIndexOutOfBoundsException instead of NumberFormatException.
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexFloat("f"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexFloat("F"));
+    }
+
+    @Test
+    void lexFloatRejectsJavaFloatSuffix() {
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexFloat("1.0f"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexFloat("1.0F"));
+    }
+
+    @Test
+    void lexFloatAcceptsValidValues() {
+        assertEquals(1.0f, XsTypeConverter.lexFloat("1.0"));
+        assertEquals(Float.POSITIVE_INFINITY, XsTypeConverter.lexFloat("INF"));
+        assertEquals(Float.NEGATIVE_INFINITY, XsTypeConverter.lexFloat("-INF"));
+    }
 }


### PR DESCRIPTION
Spotted reading the float suffix check in lexFloat: when the value is exactly "f" or "F" it reads charAt(length - 2) at index -1 and throws StringIndexOutOfBoundsException, which validateLexical doesn't catch, so a malformed xsd:float escapes validation as an unexpected runtime exception instead of an invalid-value error; only run the suffix check when there are at least two characters.