### PR TITLE
fix out-of-bounds read in trimTrailingZeros for empty decimal

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
@@ -558,7 +558,7 @@ public final class XsTypeConverter {
 
     private static String trimTrailingZeros(String xsd_decimal) {
         final int last_char_idx = xsd_decimal.length() - 1;
-        if (xsd_decimal.charAt(last_char_idx) == '0') {
+        if (last_char_idx >= 0 && xsd_decimal.charAt(last_char_idx) == '0') {
             final int last_point = xsd_decimal.lastIndexOf('.');
             if (last_point >= 0) {
                 //find last trailing zero

--- a/src/test/java/misc/checkin/XsTypeConverterTest.java
+++ b/src/test/java/misc/checkin/XsTypeConverterTest.java
@@ -76,4 +76,17 @@ public class XsTypeConverterTest {
         assertEquals(Float.POSITIVE_INFINITY, XsTypeConverter.lexFloat("INF"));
         assertEquals(Float.NEGATIVE_INFINITY, XsTypeConverter.lexFloat("-INF"));
     }
+
+    @Test
+    void lexDecimalRejectsEmptyString() {
+        // an empty value used to read charAt(-1) in trimTrailingZeros and
+        // throw StringIndexOutOfBoundsException instead of NumberFormatException.
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexDecimal(""));
+    }
+
+    @Test
+    void lexDecimalTrimsTrailingZeros() {
+        assertEquals(0, new java.math.BigDecimal("1.5").compareTo(XsTypeConverter.lexDecimal("1.500")));
+        assertEquals(0, new java.math.BigDecimal("12").compareTo(XsTypeConverter.lexDecimal("12.000")));
+    }
 }


### PR DESCRIPTION
Was fuzzing the rich-parser numeric paths with degenerate values. An empty xsd:decimal tripped this:

    java.lang.StringIndexOutOfBoundsException: Index -1 out of bounds for length 0
        at java.base/java.lang.String.charAt(String.java:1572)
        at org.apache.xmlbeans.impl.util.XsTypeConverter.trimTrailingZeros(XsTypeConverter.java:561)
        at org.apache.xmlbeans.impl.util.XsTypeConverter.lexDecimal(XsTypeConverter.java:163)

trimTrailingZeros reads charAt(length() - 1) with no length guard, so an empty value indexes charAt(-1). lexDecimal is documented to throw NumberFormatException, and XMLStreamReaderExtImpl.getBigDecimalValue only catches that, so the SIOOBE leaks out instead of being reported as an invalid value.

The empty string reaches here straight from untrusted XML once whitespace is trimmed.

Guarding the index lets an empty value fall through to new BigDecimal(""), which raises NumberFormatException like every other malformed decimal. Trailing-zero trimming is unchanged for non-empty input.