### PR TITLE
surface invalid base64 as a lexical error in the rich parser

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/richParser/XMLStreamReaderExtImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/richParser/XMLStreamReaderExtImpl.java
@@ -182,11 +182,11 @@ public class XMLStreamReaderExtImpl
         throws XMLStreamException, InvalidLexicalValueException {
         _charSeq.reload(CharSeqTrimWS.XMLWHITESPACE_TRIM);
         String text = _charSeq.toString();
-        byte[] buf = Base64.getMimeDecoder().decode(text.getBytes(StandardCharsets.ISO_8859_1));
-        if (buf != null) {
+        try {
+            byte[] buf = Base64.getMimeDecoder().decode(text.getBytes(StandardCharsets.ISO_8859_1));
             return new ByteArrayInputStream(buf);
-        } else {
-            throw new InvalidLexicalValueException("invalid base64Binary value", _charSeq.getLocation());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidLexicalValueException("invalid base64Binary value", e, _charSeq.getLocation());
         }
     }
 
@@ -332,11 +332,11 @@ public class XMLStreamReaderExtImpl
 
     public InputStream getAttributeBase64Value(int index) throws XMLStreamException {
         String text = _charSeq.reloadAtt(index, CharSeqTrimWS.XMLWHITESPACE_TRIM).toString();
-        byte[] buf = Base64.getMimeDecoder().decode(text.getBytes(StandardCharsets.ISO_8859_1));
-        if (buf != null) {
+        try {
+            byte[] buf = Base64.getMimeDecoder().decode(text.getBytes(StandardCharsets.ISO_8859_1));
             return new ByteArrayInputStream(buf);
-        } else {
-            throw new InvalidLexicalValueException("invalid base64Binary value", _charSeq.getLocation());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidLexicalValueException("invalid base64Binary value", e, _charSeq.getLocation());
         }
     }
 
@@ -486,11 +486,11 @@ public class XMLStreamReaderExtImpl
     public InputStream getAttributeBase64Value(String uri, String local) throws XMLStreamException {
         CharSequence cs = _charSeq.reloadAtt(uri, local, CharSeqTrimWS.XMLWHITESPACE_TRIM);
         String text = cs.toString();
-        byte[] buf = Base64.getMimeDecoder().decode(text.getBytes(StandardCharsets.ISO_8859_1));
-        if (buf != null) {
+        try {
+            byte[] buf = Base64.getMimeDecoder().decode(text.getBytes(StandardCharsets.ISO_8859_1));
             return new ByteArrayInputStream(buf);
-        } else {
-            throw new InvalidLexicalValueException("invalid base64Binary value", _charSeq.getLocation());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidLexicalValueException("invalid base64Binary value", e, _charSeq.getLocation());
         }
     }
 

--- a/src/test/java/misc/checkin/RichParserTests.java
+++ b/src/test/java/misc/checkin/RichParserTests.java
@@ -16,6 +16,7 @@
 package misc.checkin;
 
 import org.apache.xmlbeans.*;
+import org.apache.xmlbeans.impl.common.InvalidLexicalValueException;
 import org.apache.xmlbeans.impl.richParser.XMLStreamReaderExt;
 import org.apache.xmlbeans.impl.richParser.XMLStreamReaderExtImpl;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 /**
@@ -64,6 +66,34 @@ public class RichParserTests {
                     break;
             }
         }
+    }
+
+    @Test
+    void testInvalidBase64ThrowsInvalidLexicalValue() throws Exception {
+        // "A" is a single base64 char, the MIME decoder rejects it with
+        // IllegalArgumentException. The rich parser must surface that as the
+        // documented InvalidLexicalValueException, like the other getters.
+        XMLStreamReaderExt elem = atFirstStartElement("<a>A</a>");
+        assertThrows(InvalidLexicalValueException.class, elem::getBase64Value);
+
+        XMLStreamReaderExt attByIndex = atFirstStartElement("<a b=\"A\"/>");
+        assertThrows(InvalidLexicalValueException.class, () -> attByIndex.getAttributeBase64Value(0));
+
+        XMLStreamReaderExt attByName = atFirstStartElement("<a b=\"A\"/>");
+        assertThrows(InvalidLexicalValueException.class, () -> attByName.getAttributeBase64Value("", "b"));
+    }
+
+    private static XMLStreamReaderExt atFirstStartElement(String xml) throws Exception {
+        XMLStreamReader xsr = XmlObject.Factory.parse(xml).newXMLStreamReader();
+        XMLStreamReaderExt ext = new XMLStreamReaderExtImpl(xsr);
+        int evt = ext.getEventType();
+        while (evt != XMLEvent.START_ELEMENT && ext.hasNext()) {
+            evt = ext.next();
+        }
+        if (evt != XMLEvent.START_ELEMENT) {
+            throw new IllegalStateException("no start element in: " + xml);
+        }
+        return ext;
     }
 
     private static final String[] strings = {


### PR DESCRIPTION
the JDK MIME decoder throws IllegalArgumentException on malformed base64 such as a lone "A" and never returns null, so getBase64Value and both getAttributeBase64Value overloads let it escape rather than the documented InvalidLexicalValueException (the null check was already dead code), and wrapping the decode makes a bad value from untrusted XML surface as a lexical error like the sibling date and duration getters.