### PR TITLE
guard against integer overflow in GDuration field parsing

### DIFF
--- a/src/main/java/org/apache/xmlbeans/GDuration.java
+++ b/src/main/java/org/apache/xmlbeans/GDuration.java
@@ -120,7 +120,10 @@ public final class GDuration implements GDurationSpecification, java.io.Serializ
                 ch = (start < len) ? str.charAt(start) : '\0';
                 if (!GDate.isDigit(ch))
                     break;
-                value = value * 10 + GDate.digitVal(ch);
+                int digit = GDate.digitVal(ch);
+                if (value > (Integer.MAX_VALUE - digit) / 10)
+                    throw new IllegalArgumentException("duration field value out of range: " + str);
+                value = value * 10 + digit;
             }
             if (ch == '.')
             {

--- a/src/test/java/xmlobject/schematypes/checkin/GDateTests.java
+++ b/src/test/java/xmlobject/schematypes/checkin/GDateTests.java
@@ -108,6 +108,11 @@ public class GDateTests {
         "-P1Y1M1DT1H-1M1.1S",
         "-PT-0.1S",
         "-PT-0.1415926S",
+
+        "PT2147483648S", // overflow: Integer.MAX_VALUE + 1
+        "PT4294967296S", // overflow
+        "P4294967296Y", // overflow
+        "PT10000000000S", // overflow
     };
 
     private static final String[] invalidDates = {


### PR DESCRIPTION
Noticed durations round-tripping wrong while poking at the lexers. Reduced it to two cases:

    new GDuration("PT4294967296S")  ->  PT0S
    new GDuration("PT2147483648S")  ->  PT-2147483648S

Both are lexically valid, every field in xsd:duration is `[0-9]+` with no upper bound. The field accumulator in the `GDuration(CharSequence)` constructor is an `int` and `value = value * 10 + digit` has no overflow guard, so a field past Integer.MAX_VALUE wraps. The first input silently becomes zero seconds; the second flips a positive duration to a negative one.

GDate already caps its year and throws for years it cannot represent. GDuration had nothing equivalent, so an oversized field coming from untrusted XML was accepted as a wrong value instead of being rejected. Added the overflow check before the multiply so the field is reported as an invalid lexical value. Validation already routes the IllegalArgumentException through `JavaGDurationHolderEx.lex`, so instance parsing now flags it as a bad duration rather than handing back a wrong number.

Integer.MAX_VALUE itself still parses; only values past it are rejected. Test cases added to the existing `invalidDurations` list in GDateTests.