### PR TITLE
fix unparseable bracketless dimensions in SOAPArrayType(QName, String)

### DIFF
--- a/src/main/java/org/apache/xmlbeans/soap/SOAPArrayType.java
+++ b/src/main/java/org/apache/xmlbeans/soap/SOAPArrayType.java
@@ -118,6 +118,7 @@ public final class SOAPArrayType {
             _ranks = EMPTY_INT_ARRAY;
             dimensions = XmlWhitespace.collapse(dimensions, XmlWhitespace.WS_COLLAPSE);
             String[] dimStrings = dimensions.split(" ");
+            _dimensions = new int[dimStrings.length];
             for (int i = 0; i < dimStrings.length; i++) {
                 String dimString = dimStrings[i];
                 if (dimString.equals("*")) {

--- a/src/test/java/misc/checkin/SOAPArrayTypeTest.java
+++ b/src/test/java/misc/checkin/SOAPArrayTypeTest.java
@@ -1,0 +1,39 @@
+/*   Copyright 2026 The Apache Software Foundation
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package misc.checkin;
+
+import org.apache.xmlbeans.soap.SOAPArrayType;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.namespace.QName;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class SOAPArrayTypeTest {
+
+    private static final QName ITEM = new QName("http://example.com", "int");
+
+    @Test
+    void parsesBracketlessDimensions() {
+        SOAPArrayType t = new SOAPArrayType(ITEM, "2 3 4");
+        assertArrayEquals(new int[]{2, 3, 4}, t.getDimensions());
+    }
+
+    @Test
+    void parsesBracketlessDimensionsWithWildcard() {
+        SOAPArrayType t = new SOAPArrayType(ITEM, "* 3");
+        assertArrayEquals(new int[]{-1, 3}, t.getDimensions());
+    }
+}


### PR DESCRIPTION
Found this tracing how compiled .xsb metadata rebuilds a SOAPArrayType. XsbReader.readSOAPArrayType hands the stored dimension string to the SOAPArrayType(QName, String) constructor, and a value with no '[' takes the bracketless branch.

1. that branch writes parsed sizes straight into the _dimensions field, but the field is never allocated, so it is null.
2. "* 3" then throws NullPointerException at _dimensions[i] = -1; "2 3 4" hits the same null array under Integer.parseInt, where the catch(Exception) reports it as XmlValueOutOfRangeException, so a valid size is rejected.

newSoap12Array already allocates the array before the same loop. Allocated _dimensions the same way and added a test covering both bracketless forms.
