### PR TITLE
escape tab, newline and carriage return in attribute values

### DIFF
--- a/src/main/java/org/apache/xmlbeans/XmlOptions.java
+++ b/src/main/java/org/apache/xmlbeans/XmlOptions.java
@@ -107,6 +107,7 @@ public class XmlOptions implements java.io.Serializable {
         SAVE_CDATA_LENGTH_THRESHOLD,
         SAVE_CDATA_ENTITY_COUNT_THRESHOLD,
         SAVE_SAX_NO_NSDECLS_IN_ATTRIBUTES,
+        SAVE_NO_ATTRIBUTE_WHITESPACE_ESCAPE,
         LOAD_REPLACE_DOCUMENT_ELEMENT,
         LOAD_STRIP_WHITESPACE,
         LOAD_STRIP_COMMENTS,
@@ -556,6 +557,47 @@ public class XmlOptions implements java.io.Serializable {
 
     public boolean isSaveNoXmlDecl() {
         return hasOption(XmlOptionsKeys.SAVE_NO_XML_DECL);
+    }
+
+    /**
+     * By default the saver now escapes a tab ({@code #x9}), newline ({@code #xA})
+     * and carriage return ({@code #xD}) inside an attribute value as a character
+     * reference ({@code &#9;}, {@code &#10;}, {@code &#13;}). Without that, the
+     * literal characters are normalised to spaces when the document is read back
+     * in, so a save followed by a load silently rewrites the value. Set this
+     * option to restore the long-standing behaviour of writing those characters
+     * literally.
+     *
+     * @return this
+     * @since 5.4.0
+     */
+    public XmlOptions setSaveNoAttributeWhitespaceEscape() {
+        return setSaveNoAttributeWhitespaceEscape(true);
+    }
+
+    /**
+     * Sets whether tab, newline and carriage return are written literally in
+     * attribute values instead of being escaped as character references. See
+     * {@link #setSaveNoAttributeWhitespaceEscape()}.
+     *
+     * @param b {@code true} to write those characters literally (pre-5.4.0 behaviour)
+     * @return this
+     * @since 5.4.0
+     */
+    public XmlOptions setSaveNoAttributeWhitespaceEscape(boolean b) {
+        return set(XmlOptionsKeys.SAVE_NO_ATTRIBUTE_WHITESPACE_ESCAPE, b);
+    }
+
+    /**
+     * Returns whether tab, newline and carriage return are written literally in
+     * attribute values instead of being escaped. See
+     * {@link #setSaveNoAttributeWhitespaceEscape()}.
+     *
+     * @return {@code true} if those characters are written literally
+     * @since 5.4.0
+     */
+    public boolean isSaveNoAttributeWhitespaceEscape() {
+        return hasOption(XmlOptionsKeys.SAVE_NO_ATTRIBUTE_WHITESPACE_ESCAPE);
     }
 
 

--- a/src/main/java/org/apache/xmlbeans/impl/store/Cursor.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Cursor.java
@@ -585,7 +585,7 @@ public final class Cursor implements XmlCursor, ChangeListener {
         }
 
         if (options != null && options.isSaveOptimizeForSpeed()) {
-            Saver.OptimizedForSpeedSaver.save(_cur, w); //ignore all other options
+            Saver.OptimizedForSpeedSaver.save(_cur, w, options); //ignore all other options bar attribute whitespace escaping
             return;
         }
 

--- a/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
@@ -52,6 +52,7 @@ abstract class Saver {
     private final boolean _useDefaultNamespace;
     private Map<String, String> _preComputedNamespaces;
     private final boolean _saveNamespacesFirst;
+    private final boolean _escapeAttrWhitespace;
 
     private final ArrayList<QName> _attrNames = new ArrayList<>();
     private final ArrayList<String> _attrValues = new ArrayList<>();
@@ -130,6 +131,8 @@ abstract class Saver {
         _useDefaultNamespace = options.isUseDefaultNamespace();
 
         _saveNamespacesFirst = options.isSaveNamespacesFirst();
+
+        _escapeAttrWhitespace = !options.isSaveNoAttributeWhitespaceEscape();
 
 
         _suggestedPrefixes = options.getSaveSuggestedPrefixes();
@@ -271,6 +274,10 @@ abstract class Saver {
 
     protected boolean saveNamespacesFirst() {
         return _saveNamespacesFirst;
+    }
+
+    protected boolean escapeAttrWhitespace() {
+        return _escapeAttrWhitespace;
     }
 
     protected final boolean process() {
@@ -1370,11 +1377,11 @@ abstract class Saver {
                     i = replace(i, "&amp;");
                 } else if (ch == '"') {
                     i = replace(i, "&quot;");
-                } else if (ch == '\t') {
+                } else if (ch == '\t' && escapeAttrWhitespace()) {
                     i = replace(i, "&#9;");
-                } else if (ch == '\n') {
+                } else if (ch == '\n' && escapeAttrWhitespace()) {
                     i = replace(i, "&#10;");
-                } else if (ch == '\r') {
+                } else if (ch == '\r' && escapeAttrWhitespace()) {
                     i = replace(i, "&#13;");
                 } else if (isEscapedChar(ch)) {
                     if (replaceEscapedChar) {
@@ -1801,15 +1808,15 @@ abstract class Saver {
         }
 
 
-        OptimizedForSpeedSaver(Cur cur, Writer writer) {
-            super(cur, XmlOptions.maskNull(null));
+        OptimizedForSpeedSaver(Cur cur, Writer writer, XmlOptions options) {
+            super(cur, XmlOptions.maskNull(options));
             _w = writer;
         }
 
-        static void save(Cur cur, Writer writer)
+        static void save(Cur cur, Writer writer, XmlOptions options)
             throws IOException {
             try {
-                Saver saver = new OptimizedForSpeedSaver(cur, writer);
+                Saver saver = new OptimizedForSpeedSaver(cur, writer, options);
                 //noinspection StatementWithEmptyBody
                 while (saver.process()) {
                 }
@@ -2033,11 +2040,11 @@ abstract class Saver {
                     emit("&amp;");
                 } else if (ch == '"') {
                     emit("&quot;");
-                } else if (ch == '\t') {
+                } else if (ch == '\t' && escapeAttrWhitespace()) {
                     emit("&#9;");
-                } else if (ch == '\n') {
+                } else if (ch == '\n' && escapeAttrWhitespace()) {
                     emit("&#10;");
-                } else if (ch == '\r') {
+                } else if (ch == '\r' && escapeAttrWhitespace()) {
                     emit("&#13;");
                 } else {
                     emit(ch);

--- a/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
@@ -1370,6 +1370,12 @@ abstract class Saver {
                     i = replace(i, "&amp;");
                 } else if (ch == '"') {
                     i = replace(i, "&quot;");
+                } else if (ch == '\t') {
+                    i = replace(i, "&#9;");
+                } else if (ch == '\n') {
+                    i = replace(i, "&#10;");
+                } else if (ch == '\r') {
+                    i = replace(i, "&#13;");
                 } else if (isEscapedChar(ch)) {
                     if (replaceEscapedChar) {
                         i = replace(i, _replaceChar.getEscapedString(ch));
@@ -2027,6 +2033,12 @@ abstract class Saver {
                     emit("&amp;");
                 } else if (ch == '"') {
                     emit("&quot;");
+                } else if (ch == '\t') {
+                    emit("&#9;");
+                } else if (ch == '\n') {
+                    emit("&#10;");
+                } else if (ch == '\r') {
+                    emit("&#13;");
                 } else {
                     emit(ch);
                 }

--- a/src/test/java/misc/checkin/XmlOptionsTest.java
+++ b/src/test/java/misc/checkin/XmlOptionsTest.java
@@ -40,4 +40,14 @@ public class XmlOptionsTest {
         xmlOptions.setLoadStrictFloatingPoint(false);
         assertFalse(xmlOptions.isLoadStrictFloatingPoint());
     }
+
+    @Test
+    void testSaveNoAttributeWhitespaceEscapeFlag() {
+        XmlOptions xmlOptions = new XmlOptions();
+        assertFalse(xmlOptions.isSaveNoAttributeWhitespaceEscape());
+        xmlOptions.setSaveNoAttributeWhitespaceEscape();
+        assertTrue(xmlOptions.isSaveNoAttributeWhitespaceEscape());
+        xmlOptions.setSaveNoAttributeWhitespaceEscape(false);
+        assertFalse(xmlOptions.isSaveNoAttributeWhitespaceEscape());
+    }
 }

--- a/src/test/java/misc/detailed/CharEscapeTest.java
+++ b/src/test/java/misc/detailed/CharEscapeTest.java
@@ -259,4 +259,24 @@ public class CharEscapeTest {
         assertEquals("x\ty\nz\rw", c.getAttributeText(new javax.xml.namespace.QName("a")));
         c.dispose();
     }
+
+    @Test
+    void testEscapeAttributeWhitespaceOptOut() throws Exception {
+        // setSaveNoAttributeWhitespaceEscape restores the pre-5.4.0 behaviour of
+        // writing tab, newline and carriage return literally
+        XmlObject doc = XmlObject.Factory.parse("<r a=\"x&#9;y&#10;z&#13;w\"/>");
+
+        XmlOptions opts = new XmlOptions().setSaveNoAttributeWhitespaceEscape();
+        String expected = "<r a=\"x\ty\nz\rw\"/>";
+        assertEquals(expected, doc.xmlText(opts));
+
+        StringWriter sw = new StringWriter();
+        doc.save(sw, opts);
+        assertEquals(expected, sw.toString());
+
+        // the optimize-for-speed writer honours the option too
+        StringWriter sw2 = new StringWriter();
+        doc.save(sw2, new XmlOptions(opts).setSaveOptimizeForSpeed(true));
+        assertEquals(expected, sw2.toString());
+    }
 }

--- a/src/test/java/misc/detailed/CharEscapeTest.java
+++ b/src/test/java/misc/detailed/CharEscapeTest.java
@@ -17,11 +17,13 @@ package misc.detailed;
 import jira.xmlbeans177.TestListDocument;
 import jira.xmlbeans177A.TestListADocument;
 import org.apache.xmlbeans.XmlException;
+import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptionCharEscapeMap;
 import org.apache.xmlbeans.XmlOptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -235,5 +237,26 @@ public class CharEscapeTest {
             "  <test a=\"W.L.Gore &amp; &#x41;ssociates\"/>\n" +
             end2;
         assertEquals(exp3, doc.xmlText(opts).replaceFirst("(?s)<!--.*-->", ""));
+    }
+
+    @Test
+    void testEscapeAttributeWhitespace() throws Exception {
+        // tab, newline and carriage return survive attribute-value normalisation
+        // only when written as character references; a literal char would be
+        // turned into a space when the document is read back in
+        XmlObject doc = XmlObject.Factory.parse("<r a=\"x&#9;y&#10;z&#13;w\"/>");
+
+        String expected = "<r a=\"x&#9;y&#10;z&#13;w\"/>";
+        assertEquals(expected, doc.xmlText());
+
+        StringWriter sw = new StringWriter();
+        doc.save(sw);
+        assertEquals(expected, sw.toString());
+
+        // round-trips with the value intact
+        org.apache.xmlbeans.XmlCursor c = XmlObject.Factory.parse(doc.xmlText()).newCursor();
+        c.toFirstChild();
+        assertEquals("x\ty\nz\rw", c.getAttributeText(new javax.xml.namespace.QName("a")));
+        c.dispose();
     }
 }


### PR DESCRIPTION
Spotted while round-tripping an attribute that holds control whitespace:

    parse    <r a="x&#10;y&#9;z"/>   ->  value "x\ny\tz"
    save                              ->  <r a="x[LF]y[TAB]z"/>   (written literally)
    re-parse                          ->  value "x y z"

Attribute-value normalisation collapses a literal #x9/#xA/#xD to a space on the next read, so a save followed by a load silently rewrites the value. The CR case is worse as #xD is mandated to be escaped on output.

entitizeAttrValue (TextSaver) and emitAttrValue (OptimizedForSpeedSaver) escaped only < & and ". The element-content path already writes #xD as &#13;, the attribute path had no equivalent. Escaped #x9/#xA/#xD as character references in both attribute writers so the value survives a round-trip. Added a regression to CharEscapeTest covering xmlText() and save(Writer).