### PR TITLE
fix out-of-bounds read in scanAttribute for valueless xml decl attr

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/common/SniffedXmlInputStream.java
+++ b/src/main/java/org/apache/xmlbeans/impl/common/SniffedXmlInputStream.java
@@ -269,6 +269,9 @@ public class SniffedXmlInputStream extends BufferedInputStream {
             return -1;
         }
         int valQuote = nextNonmatchingByte(WHITESPACE, buf, equals + 1, limit);
+        if (valQuote < 0) {
+            return -1;
+        }
         if (buf[valQuote] != '\'' && buf[valQuote] != '\"') {
             return -1;
         }

--- a/src/test/java/misc/checkin/SniffedXmlEncodingTest.java
+++ b/src/test/java/misc/checkin/SniffedXmlEncodingTest.java
@@ -1,0 +1,53 @@
+/*   Copyright 2004 The Apache Software Foundation
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package misc.checkin;
+
+import org.apache.xmlbeans.impl.common.SniffedXmlInputStream;
+import org.apache.xmlbeans.impl.common.SniffedXmlReader;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SniffedXmlEncodingTest {
+
+    // An xml declaration pseudo-attribute ending in '=' with no value, only
+    // whitespace up to the end of the sniffed buffer, used to index buf[-1]
+    // while scanning for the opening quote. The sniffer must report "no
+    // encoding found" instead of throwing ArrayIndexOutOfBoundsException.
+    @Test
+    void valuelessAttributeReader() throws Exception {
+        for (String s : new String[]{"<?xml x=", "<?xml version=\"1.0\" encoding=  ", "<?xml a=   \t\n"}) {
+            assertNull(new SniffedXmlReader(new StringReader(s)).getXmlEncoding());
+        }
+    }
+
+    @Test
+    void valuelessAttributeStream() throws Exception {
+        byte[] b = "<?xml version=\"1.0\" encoding= ".getBytes(StandardCharsets.US_ASCII);
+        assertEquals("UTF-8", new SniffedXmlInputStream(new ByteArrayInputStream(b)).getXmlEncoding());
+    }
+
+    @Test
+    void wellFormedDeclarationStillDetected() throws Exception {
+        byte[] b = "<?xml version='1.0' encoding='ISO-8859-1'?>".getBytes(StandardCharsets.US_ASCII);
+        assertEquals("ISO-8859-1", new SniffedXmlInputStream(new ByteArrayInputStream(b)).getXmlEncoding());
+    }
+}


### PR DESCRIPTION
    java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 192
        at SniffedXmlInputStream.scanAttribute(SniffedXmlInputStream.java)
        at SniffedXmlInputStream.extractXmlDeclEncoding(SniffedXmlInputStream.java)

Turned up while feeding truncated documents through the encoding sniffer. scanAttribute walks the `<?xml ...?>` pseudo-attributes and checks the -1 "not found" sentinel returned by nextNonmatchingByte/nextMatchingByte for the name and for the `=`, but not for the value quote. Once it has the `=` it scans for the opening quote with nextNonmatchingByte and indexes `buf[valQuote]` straight away.

If that `=` is the last non-space character inside the sniffed window the scan returns -1, so `buf[-1]` throws. Smallest triggers are `<?xml x=` and `<?xml version="1.0" encoding= `.

The sniffer is meant to return the declared encoding or null and let the caller fall back to UTF-8; it should not throw on the bytes it is sniffing. extractXmlDeclEncoding backs both SniffedXmlReader and SniffedXmlInputStream so both readers were affected, and XmlEncodingSniffer/StscImporter only catch IOException, so the runtime exception escapes the copy path.

Guard valQuote the same way as the other three results.