### PR TITLE
fix pi terminator breakout after bad char in entitizeProcinst

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
@@ -1452,7 +1452,8 @@ abstract class Saver {
                 char ch = _cbuf[i];
 
                 if (isBadChar(ch)) {
-                    i = replace(i, "?");
+                    replace(i, "?");
+                    ch = '?';
                 }
 
                 if (ch == '>') {

--- a/src/test/java/misc/checkin/ProcInstEscapeTest.java
+++ b/src/test/java/misc/checkin/ProcInstEscapeTest.java
@@ -1,0 +1,67 @@
+/*   Copyright 2004 The Apache Software Foundation
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package misc.checkin;
+
+import org.apache.xmlbeans.XmlCursor;
+import org.apache.xmlbeans.XmlObject;
+import org.apache.xmlbeans.XmlOptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ProcInstEscapeTest {
+
+    private static XmlObject docWithProcInst(String piText) throws Exception {
+        XmlObject o = XmlObject.Factory.parse("<root>x</root>");
+        try (XmlCursor c = o.newCursor()) {
+            c.toNextToken();
+            c.toNextToken();
+            c.insertProcInst("tgt", piText);
+        }
+        return o;
+    }
+
+    private static String saveForSpeed(XmlObject o) throws Exception {
+        XmlOptions opts = new XmlOptions();
+        opts.setSaveOptimizeForSpeed(true);
+        StringWriter sw = new StringWriter();
+        o.save(sw, opts);
+        return sw.toString();
+    }
+
+    // a bad char immediately before "?>" used to make the default saver skip the
+    // "?>" so it survived inside the processing instruction
+    @Test
+    void testBadCharBeforePiEnd() throws Exception {
+        XmlObject o = docWithProcInst("\u0007?>");
+        String out = o.xmlText();
+        assertEquals("<root><?tgt ?? ?>x</root>", out);
+        // the only "?>" in the output is the PI terminator
+        assertFalse(out.substring(0, out.indexOf("?>x")).contains("?>"));
+        // round-trips and both savers agree
+        XmlObject.Factory.parse(out);
+        assertEquals(out, saveForSpeed(o));
+    }
+
+    @Test
+    void testPlainQuestionGtStillEscaped() throws Exception {
+        XmlObject o = docWithProcInst("a?>b");
+        assertEquals("<root><?tgt a? b?>x</root>", o.xmlText());
+    }
+}


### PR DESCRIPTION
Found while checking the default save path copes with control chars in markup.

    pi text: "?>"
    saved  : <?tgt ??>?>     (the data keeps a live "?>")
    reparse: the PI closes at the first "?>"

entitizeProcinst replaces a bad char with '?' through `i = replace(i, "?")`, which already steps i forward, and then the if/else below steps i again. The char sitting after the bad char is skipped and never tested, so a following "?>" survives in the PI data and ends the instruction early.

OptimizedForSpeedSaver.entitizeAndWritePIText does the same sanitising with `ch = '?'` and a single step and gets it right. Aligned entitizeProcinst with it, so the synthesised '?' takes part in the "?>" check. Saved output is now `<?tgt ?? ?>`.

Only triggers when a bad char precedes "?>"; ordinary "?>" was already broken correctly.