### PR TITLE
reject double leading sign in lexLong and lexInteger

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
@@ -275,11 +275,7 @@ public final class XsTypeConverter {
     // ======================== integer ========================
     public static BigInteger lexInteger(CharSequence cs)
         throws NumberFormatException {
-        if (cs.length() > 1) {
-            if (cs.charAt(0) == '+' && cs.charAt(1) == '-') {
-                throw new NumberFormatException("Illegal char sequence '+-'");
-            }
-        }
+        rejectSignAfterPlus(cs);
         final String v = cs.toString();
 
         //TODO: consider special casing zero and one to return static values
@@ -304,8 +300,23 @@ public final class XsTypeConverter {
     // ======================== long ========================
     public static long lexLong(CharSequence cs)
         throws NumberFormatException {
+        rejectSignAfterPlus(cs);
         final String v = cs.toString();
         return Long.parseLong(trimInitialPlus(v));
+    }
+
+    // trimInitialPlus drops a single leading '+', then Long.parseLong /
+    // new BigInteger accept their own leading sign, so "++5" and "+-5" slip
+    // through as 5 and -5. Neither is in the xsd integer lexical space
+    // ([\-+]?[0-9]+ allows one sign). lexInt/lexShort/lexByte already reject
+    // the second sign in parseIntXsdNumber.
+    private static void rejectSignAfterPlus(CharSequence cs) {
+        if (cs.length() > 1 && cs.charAt(0) == '+') {
+            final char c = cs.charAt(1);
+            if (c == '+' || c == '-') {
+                throw new NumberFormatException("Illegal char sequence '+" + c + "'");
+            }
+        }
     }
 
     public static long lexLong(CharSequence cs, Collection<XmlError> errors) {

--- a/src/test/java/misc/checkin/XsTypeConverterTest.java
+++ b/src/test/java/misc/checkin/XsTypeConverterTest.java
@@ -167,6 +167,25 @@ public class XsTypeConverterTest {
     }
 
     @Test
+    void lexLongRejectsDoubleSign() {
+        // trimInitialPlus drops the leading '+', then Long.parseLong accepts its
+        // own sign, so "++5"/"+-5" used to parse as 5/-5 instead of being rejected.
+        assertEquals(5L, XsTypeConverter.lexLong("+5"));
+        assertEquals(-5L, XsTypeConverter.lexLong("-5"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexLong("++5"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexLong("+-5"));
+    }
+
+    @Test
+    void lexIntegerRejectsDoubleSign() {
+        // "+-5" was already caught; "++5" leaked through as 5.
+        assertEquals(java.math.BigInteger.valueOf(5), XsTypeConverter.lexInteger("+5"));
+        assertEquals(java.math.BigInteger.valueOf(-5), XsTypeConverter.lexInteger("-5"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexInteger("++5"));
+        assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexInteger("+-5"));
+    }
+
+    @Test
     void lexDecimalRejectsEmptyString() {
         // an empty value used to read charAt(-1) in trimTrailingZeros and
         // throw StringIndexOutOfBoundsException instead of NumberFormatException.


### PR DESCRIPTION
Noticed while comparing the integer lexers: lexInteger guards "+-" but lexLong has no guard at all.

    XsTypeConverter.lexLong("++5")    -> 5
    XsTypeConverter.lexLong("+-5")    -> -5
    XsTypeConverter.lexInteger("++5") -> 5

trimInitialPlus drops one leading "+", then Long.parseLong and new BigInteger each accept their own leading sign, so a second sign slips through. The xsd:integer/long lexical space allows one optional sign only, and lexInt/lexShort/lexByte already reject the second sign in parseIntXsdNumber. Through the rich parser getLongValue/getBigIntegerValue this hands back a wrong (or sign-flipped) value rather than a lexical error.

The old lexInteger check caught "+-" but missed "++". Folded both cases into one guard shared by lexLong and lexInteger.