### PR TITLE
fix out-of-bounds read in RANGE op of RegularExpression.match

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/regex/RegularExpression.java
+++ b/src/main/java/org/apache/xmlbeans/impl/regex/RegularExpression.java
@@ -1091,7 +1091,7 @@ public class RegularExpression implements java.io.Serializable {
                             returned = true;
                             break;
                         }
-                        int ch = target.charAt(offset);
+                        int ch = target.charAt(o1);
                         if (REUtil.isHighSurrogate(ch) && o1+dx < con.limit && o1+dx >=0) {
                             o1 += dx;
                             ch = REUtil.composeFromSurrogates(ch, target.charAt(o1));

--- a/src/test/java/misc/checkin/RegularExpressionTest.java
+++ b/src/test/java/misc/checkin/RegularExpressionTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RegularExpressionTest {
@@ -29,6 +30,18 @@ public class RegularExpressionTest {
         RegularExpression regex = new RegularExpression("[A-Z0-9]+");
         String rnd = randomString(10000);
         assertTrue(regex.matches(rnd));
+    }
+
+    @Test
+    void testLookbehindRangeAtInputEnd() {
+        // a lookbehind containing a character class, evaluated at the end of the
+        // input, used to read one character past the string in the RANGE op and
+        // throw StringIndexOutOfBoundsException
+        assertTrue(new RegularExpression("(?<=[a-c])$").matches("abc"));
+        assertTrue(new RegularExpression(".*(?<=[0-9])").matches("ab9"));
+        // the same off-by-one read also returned the wrong match result: the char
+        // before the lookbehind is 'x', not in [a-c], so this must not match
+        assertFalse(new RegularExpression("x(?<=[a-c])").matches("xc"));
     }
 
 


### PR DESCRIPTION
the RANGE op reads target.charAt(offset) after bounds-checking o1, so a lookbehind with a character class at the end of input reads one past the string and throws StringIndexOutOfBoundsException; the neighbouring CHAR and DOT ops already read the checked o1.