### PR TITLE
fix pi terminator breakout across chunk boundary in emitPiText

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
@@ -2089,10 +2089,11 @@ abstract class Saver {
             int cch = c._cchSrc;
             int off = c._offSrc;
             int index = 0;
+            boolean lastWasQuestion = false;
             while (index < cch) {
                 int indexLimit = Math.min(index + 512, cch);
                 CharUtil.getChars(_buf, 0, src, off + index, indexLimit - index);
-                entitizeAndWritePIText(indexLimit - index);
+                lastWasQuestion = entitizeAndWritePIText(indexLimit - index, lastWasQuestion);
                 index = indexLimit;
             }
         }
@@ -2164,9 +2165,7 @@ abstract class Saver {
             emit(_buf, 0, bufLimit);
         }
 
-        private void entitizeAndWritePIText(int bufLimit) {
-            boolean lastWasQuestion = false;
-
+        private boolean entitizeAndWritePIText(int bufLimit, boolean lastWasQuestion) {
             for (int i = 0; i < bufLimit; i++) {
                 char ch = _buf[i];
 
@@ -2187,6 +2186,7 @@ abstract class Saver {
                 }
             }
             emit(_buf, 0, bufLimit);
+            return lastWasQuestion;
         }
     }
 

--- a/src/test/java/misc/checkin/SaveOptimizeForSpeedTest.java
+++ b/src/test/java/misc/checkin/SaveOptimizeForSpeedTest.java
@@ -15,6 +15,7 @@
 
 package misc.checkin;
 
+import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptions;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import java.io.StringWriter;
 import java.time.Duration;
 import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,5 +64,24 @@ public class SaveOptimizeForSpeedTest {
         });
         XmlObject.Factory.parse(out);
         assertTrue(out.contains(LONG));
+    }
+
+    @Test
+    void testProcInstTerminatorAcrossChunkBoundary() throws Exception {
+        // a '?>' that straddles the 512-char chunk boundary: '?' is the last char
+        // of the first chunk, '>' the first char of the second. The per-chunk
+        // question-mark state used to reset between chunks, so the '>' escaped the
+        // processing instruction and the trailing text broke out of the pi.
+        String data = repeat('x', 511) + "?>" + repeat('y', 600);
+        XmlObject o = XmlObject.Factory.parse("<root>z</root>");
+        try (XmlCursor cur = o.newCursor()) {
+            cur.toFirstChild();
+            cur.toFirstContentToken();
+            cur.insertProcInst("tgt", data);
+        }
+        String out = saveForSpeed(o);
+        assertFalse(out.contains("?>" + repeat('y', 600)));
+        // breakout produced text that is not allowed where the pi sat, so this throws before the fix
+        XmlObject.Factory.parse(out);
     }
 }


### PR DESCRIPTION
OptimizedForSpeedSaver writes processing-instruction text in 512-char chunks. entitizeAndWritePIText neutralises a `?>` in the data by turning the `>` into a space, but it kept the "last char was ?" flag in a local that was reset on every chunk call.

So when a `?>` straddles the boundary, with the `?` ending one chunk and the `>` starting the next, the `>` went out unescaped and the pi terminated early. Spotted it while saving a pi whose text held a `?>` near 512 chars.

Reproduced with optimizeForSpeed on a pi built via XmlCursor.insertProcInst, text `"x"*511 + "?>" + "y"*600`. Before: the saved output contained the literal `?>` followed by the trailing text and re-parsing threw. After: the boundary `>` is escaped the same way an in-chunk one is and the output re-parses.

The comment emitter does not have this because it already forces a trailing `-` of each chunk to a space; the pi emitter had no equivalent, so I threaded the flag through instead. Added a regression test next to the existing pi/comment chunking ones.