### PR TITLE
validate NCName parts of xsd:QName in lexQName

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
@@ -17,6 +17,7 @@ package org.apache.xmlbeans.impl.util;
 
 import org.apache.xmlbeans.*;
 import org.apache.xmlbeans.impl.common.InvalidLexicalValueException;
+import org.apache.xmlbeans.impl.common.XMLChar;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
@@ -480,6 +481,13 @@ public final class XsTypeConverter {
         } else {
             prefix = EMPTY_PREFIX;
             localname = charSeq.toString();
+        }
+
+        if (!prefix.isEmpty() && !XMLChar.isValidNCName(prefix)) {
+            throw new InvalidLexicalValueException("invalid xsd:QName '" + charSeq + "'");
+        }
+        if (!XMLChar.isValidNCName(localname)) {
+            throw new InvalidLexicalValueException("invalid xsd:QName '" + charSeq + "'");
         }
 
         String uri = nscontext.getNamespaceURI(prefix);

--- a/src/test/java/misc/checkin/RichParserTests.java
+++ b/src/test/java/misc/checkin/RichParserTests.java
@@ -83,6 +83,30 @@ public class RichParserTests {
         assertThrows(InvalidLexicalValueException.class, () -> attByName.getAttributeBase64Value("", "b"));
     }
 
+    @Test
+    void testInvalidQNameThrowsInvalidLexicalValue() throws Exception {
+        // The localname of an xsd:QName must be an NCName, so a value whose
+        // local part still contains a ':' (or any other non-NCName char) is
+        // outside the lexical space. lexQName resolved the prefix but never
+        // checked the parts, so "p:b:c" came back as QName{uri}b:c instead of
+        // being rejected like the holder validate path does.
+        XMLStreamReaderExt colonInLocal = atFirstStartElement("<a xmlns:p='urn:x'>p:b:c</a>");
+        assertThrows(InvalidLexicalValueException.class, colonInLocal::getQNameValue);
+
+        XMLStreamReaderExt spaceInLocal = atFirstStartElement("<a>b c</a>");
+        assertThrows(InvalidLexicalValueException.class, spaceInLocal::getQNameValue);
+
+        XMLStreamReaderExt emptyLocal = atFirstStartElement("<a xmlns:p='urn:x'>p:</a>");
+        assertThrows(InvalidLexicalValueException.class, emptyLocal::getQNameValue);
+
+        XMLStreamReaderExt attColon = atFirstStartElement("<a xmlns:p='urn:x' b='p:b:c'/>");
+        assertThrows(InvalidLexicalValueException.class, () -> attColon.getAttributeQNameValue(0));
+
+        // a well-formed prefixed QName still resolves
+        XMLStreamReaderExt good = atFirstStartElement("<a xmlns:p='urn:x'>p:good</a>");
+        assertEquals(new QName("urn:x", "good"), good.getQNameValue());
+    }
+
     private static XMLStreamReaderExt atFirstStartElement(String xml) throws Exception {
         XMLStreamReader xsr = XmlObject.Factory.parse(xml).newXMLStreamReader();
         XMLStreamReaderExt ext = new XMLStreamReaderExtImpl(xsr);


### PR DESCRIPTION
Found while checking how the rich parser turns element text into a QName.

    XMLStreamReaderExtImpl.getQNameValue() on <a xmlns:p='urn:x'>p:b:c</a>
    returned {urn:x}b:c, a local part with a colon still in it

lexQName splits the value at the first colon and keeps everything after it as the local part, but it never checks that the prefix and local part are NCNames. So `p:b:c`, `b c` and `p:` all came back as QNames rather than being rejected as outside the xsd:QName lexical space. The rich parser getQNameValue / getAttributeQNameValue getters are the only callers of this overload, so the bad value flows straight in from untrusted XML.

JavaQNameHolder.parse on the validate path already guards both parts with isValidNCName. I added the same two checks to lexQName so it throws InvalidLexicalValueException, which getQNameValue already catches. Leading-colon handling and prefix resolution are unchanged.