### PR TITLE
reject out-of-range quantifier counts in RegexParser

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/regex/RegexParser.java
+++ b/src/main/java/org/apache/xmlbeans/impl/regex/RegexParser.java
@@ -604,9 +604,9 @@ class RegexParser {
                     min = ch -'0';
                     while (off < this.regexlen
                            && (ch = this.regex.charAt(off++)) >= '0' && ch <= '9') {
-                        min = min*10 +ch-'0';
-                        if (min < 0)
+                        if (min > (Integer.MAX_VALUE - (ch-'0')) / 10)
                             throw ex("parser.quantifier.5", this.offset);
+                        min = min*10 +ch-'0';
                     }
                 }
                 else {
@@ -625,9 +625,9 @@ class RegexParser {
                         while (off < this.regexlen
                                && (ch = this.regex.charAt(off++)) >= '0'
                                && ch <= '9') {
-                            max = max*10 +ch-'0';
-                            if (max < 0)
+                            if (max > (Integer.MAX_VALUE - (ch-'0')) / 10)
                                 throw ex("parser.quantifier.5", this.offset);
+                            max = max*10 +ch-'0';
                         }
 
                         if (min > max)

--- a/src/test/java/misc/checkin/RegularExpressionTest.java
+++ b/src/test/java/misc/checkin/RegularExpressionTest.java
@@ -15,12 +15,14 @@
 
 package misc.checkin;
 
+import org.apache.xmlbeans.impl.regex.ParseException;
 import org.apache.xmlbeans.impl.regex.RegularExpression;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RegularExpressionTest {
@@ -42,6 +44,23 @@ public class RegularExpressionTest {
         // the same off-by-one read also returned the wrong match result: the char
         // before the lookbehind is 'x', not in [a-c], so this must not match
         assertFalse(new RegularExpression("x(?<=[a-c])").matches("xc"));
+    }
+
+    @Test
+    void testQuantifierOverflow() {
+        // a {min,max} count larger than Integer.MAX_VALUE overflowed the int
+        // accumulator. the only guard was a post-multiply min<0/max<0 check, so
+        // counts that wrapped to a non-negative value slipped through: "a{4294967296}"
+        // parsed as "a{0}" (matched the empty string) and "a{1,4294967298}" as "a{1,2}",
+        // while bigger ones such as "a{99999999999}" blew the heap at match time.
+        assertThrows(ParseException.class, () -> new RegularExpression("a{4294967296}"));
+        assertThrows(ParseException.class, () -> new RegularExpression("a{4294967297}"));
+        assertThrows(ParseException.class, () -> new RegularExpression("a{99999999999}"));
+        assertThrows(ParseException.class, () -> new RegularExpression("a{1,4294967298}"));
+        // counts up to Integer.MAX_VALUE are representable and must still parse
+        new RegularExpression("a{2147483647}");
+        new RegularExpression("a{0,2147483647}");
+        assertTrue(new RegularExpression("a{2,4}").matches("aaa"));
     }
 
 


### PR DESCRIPTION
the {min,max} loop in parseFactor accumulates the count in an int but only checks for a negative wrap afterwards, so a value like a{4294967296} slips past as a{0} (matching the empty string) and a{99999999999} exhausts the heap when matched; guard against the overflow before the multiply so an out-of-range count throws the parser.quantifier.5 it was always meant to.