### PR TITLE
reject trailing dot with no fractional digits in GDate parse

### DIFF
--- a/src/main/java/org/apache/xmlbeans/GDate.java
+++ b/src/main/java/org/apache/xmlbeans/GDate.java
@@ -281,6 +281,9 @@ public final class GDate implements GDateSpecification, java.io.Serializable {
                         }
                         throw new IllegalArgumentException();
                     }
+                } else {
+                    // a '.' must be followed by at least one fractional digit
+                    throw new IllegalArgumentException("fractional seconds must contain at least one digit");
                 }
             }
 

--- a/src/test/java/xmlobject/schematypes/checkin/GDateTests.java
+++ b/src/test/java/xmlobject/schematypes/checkin/GDateTests.java
@@ -184,6 +184,9 @@ public class GDateTests {
         "00:00:00-14:01", // tz
         "00:00:00+15:00", // tz
         "00:00:00-15:00", // tz
+        "1996-02-29T00:00:00.", // trailing '.' with no fractional digits
+        "00:00:00.", // trailing '.' with no fractional digits
+        "2001-12-31T07:00:59.Z", // '.' followed by timezone, no fractional digits
     };
 
     private static final String[] validDates = {


### PR DESCRIPTION
a trailing '.' after the seconds in GDate's date/time parse was accepted with no fractional digit, because the fraction is only read inside an `if (start + 1 < len)` guard, so values such as 2000-01-01T12:00:00. and 12:00:00. parsed as a valid zero fraction (the same lexical reaches the rich parser getDateValue/getCalendarValue and the validating GDate holder, and isValid only range-checks fields); GDuration already rejects the equivalent PT5.S, so this throws when the dot is not followed by a digit.