### PR TITLE
fix out-of-bounds substring in lexQName error-collecting overload

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
+++ b/src/main/java/org/apache/xmlbeans/impl/util/XsTypeConverter.java
@@ -533,7 +533,7 @@ public final class XsTypeConverter {
         } catch (InvalidLexicalValueException e) {
             errors.add(XmlError.forMessage(e.getMessage()));
             final int idx = xsd_qname.indexOf(NAMESPACE_SEP);
-            return new QName(null, xsd_qname.substring(idx));
+            return idx < 0 ? new QName(xsd_qname) : new QName(null, xsd_qname.substring(idx));
         }
     }
 

--- a/src/test/java/misc/checkin/XsTypeConverterTest.java
+++ b/src/test/java/misc/checkin/XsTypeConverterTest.java
@@ -281,4 +281,28 @@ public class XsTypeConverterTest {
         assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexInteger("1E5"));
         assertThrows(NumberFormatException.class, () -> XsTypeConverter.lexInteger("1e5"));
     }
+
+    @Test
+    void lexQNameCollectsErrorForColonlessInvalidValue() {
+        // The error-collecting overload must record a lexical error and return a
+        // best-effort QName, never throw. A colon-less value that is not a valid
+        // NCName ("a b", "") has no ':' so the recovery indexOf returns -1.
+        javax.xml.namespace.NamespaceContext ctx = new javax.xml.namespace.NamespaceContext() {
+            public String getNamespaceURI(String prefix) { return ""; }
+            public String getPrefix(String uri) { return ""; }
+            public java.util.Iterator<String> getPrefixes(String uri) {
+                return java.util.Collections.<String>emptyList().iterator();
+            }
+        };
+
+        java.util.List<org.apache.xmlbeans.XmlError> errors = new java.util.ArrayList<>();
+        javax.xml.namespace.QName q = XsTypeConverter.lexQName("a b", errors, ctx);
+        assertEquals("a b", q.getLocalPart());
+        assertEquals(1, errors.size());
+
+        errors.clear();
+        javax.xml.namespace.QName empty = XsTypeConverter.lexQName("", errors, ctx);
+        assertEquals("", empty.getLocalPart());
+        assertEquals(1, errors.size());
+    }
 }


### PR DESCRIPTION
Turned up while feeding malformed values through the QName lexer.

    java.lang.StringIndexOutOfBoundsException: String index out of range: -1
        at java.base/java.lang.String.substring(String.java:1837)
        at org.apache.xmlbeans.impl.util.XsTypeConverter.lexQName(XsTypeConverter.java:536)

The error-collecting overload is supposed to record the lexical error and hand back a best-effort QName, not throw. The recovery branch does indexOf(':') then substring(idx), so it assumes a colon is present. A colon-less value that fails NCName validation ("a b", or the empty string) gives idx = -1, and substring(-1) escapes the error path. Colon-bearing values behave as before.

When there is no colon the whole string is the local part, so that is what gets returned.