### PR TITLE
use correct error key for out-of-range hex escape in RegexParser

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/regex/RegexParser.java
+++ b/src/main/java/org/apache/xmlbeans/impl/regex/RegexParser.java
@@ -1054,7 +1054,7 @@ class RegexParser {
               if (this.read() != T_CHAR || (v2 = hexChar(this.chardata)) < 0)
                   throw ex("parser.descape.1", this.offset - 1);
               uv2 = uv2 * 16 + v2;
-              if (uv2 > Token.UTF16_MAX) throw ex("parser.descappe.4", this.offset - 1);
+              if (uv2 > Token.UTF16_MAX) throw ex("parser.descape.4", this.offset - 1);
               c = uv2;
               break;
           }

--- a/src/test/java/misc/checkin/RegularExpressionTest.java
+++ b/src/test/java/misc/checkin/RegularExpressionTest.java
@@ -47,6 +47,20 @@ public class RegularExpressionTest {
     }
 
     @Test
+    void testHexEscapeOverflowErrorKey() {
+        // a \v escape (6 hex digits) whose value is above U+10FFFF was reported with
+        // the error key "parser.descappe.4", which is not in the message bundle, so
+        // ResourceBundle.getString threw MissingResourceException instead of the
+        // ParseException callers expect. The sibling \x{...} path already reports the
+        // same condition cleanly via "parser.descape.4".
+        assertThrows(ParseException.class, () -> new RegularExpression("\\v110000"));
+        assertThrows(ParseException.class, () -> new RegularExpression("\\vFFFFFF"));
+        assertThrows(ParseException.class, () -> new RegularExpression("\\x{110000}"));
+        // the top of the Unicode range is still valid and must parse
+        new RegularExpression("\\v10FFFF");
+    }
+
+    @Test
     void testQuantifierOverflow() {
         // a {min,max} count larger than Integer.MAX_VALUE overflowed the int
         // accumulator. the only guard was a post-multiply min<0/max<0 check, so


### PR DESCRIPTION
    java.util.MissingResourceException: Can't find resource for bundle
    java.util.PropertyResourceBundle, key parser.descappe.4

Turned up while feeding the engine out-of-range escapes through the public RegularExpression API. A `\v` escape reads six hex digits; when the value is above U+10FFFF the parser means to reject it, but the key handed to `ex()` is `parser.descappe.4`, which is not in message.properties. The real key is `parser.descape.4`. `ex()` looks the key up with `ResourceBundle.getString`, so the lookup throws MissingResourceException rather than the ParseException the rest of the parser raises.

So `\v110000` and `\vFFFFFF` leave the parser as MissingResourceException instead of a clean ParseException. The `\x{...}` branch just above reports the same overflow correctly via `parser.descape.4`, which is what flagged the typo.

One character on the key. Regression test sits next to the quantifier-overflow one.