### PR TITLE
read byte-array length as unsigned short in XsbReader

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/XsbReader.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/XsbReader.java
@@ -1755,7 +1755,7 @@ class XsbReader {
 
     byte[] readByteArray() {
         try {
-            int len = _input.readShort();
+            int len = _input.readUnsignedShort();
             byte[] result = new byte[len];
             _input.readFully(result);
             return result;

--- a/src/test/java/org/apache/xmlbeans/impl/schema/XsbReaderByteArrayTest.java
+++ b/src/test/java/org/apache/xmlbeans/impl/schema/XsbReaderByteArrayTest.java
@@ -1,0 +1,62 @@
+/*   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.xmlbeans.impl.schema;
+
+import org.apache.xmlbeans.impl.util.LongUTFDataInputStream;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class XsbReaderByteArrayTest {
+
+    /**
+     * writeByteArray stores the length with writeShort, which accepts any
+     * unsigned short (0..65535). readByteArray must read it back the same way.
+     * A length above Short.MAX_VALUE used to come back negative and blew up in
+     * new byte[len] with NegativeArraySizeException.
+     */
+    @Test
+    void readsByteArrayLengthAboveShortMax() throws Exception {
+        final int len = 40000; // > Short.MAX_VALUE, still a valid unsigned short
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeShort(len); // same on-wire form as XsbReader.writeByteArray
+        byte[] payload = new byte[len];
+        for (int i = 0; i < len; i++) {
+            payload[i] = (byte) (i & 0xff);
+        }
+        dos.write(payload);
+        dos.flush();
+
+        XsbReader reader = new XsbReader(new SchemaTypeSystemImpl("test"), "h");
+        Field input = XsbReader.class.getDeclaredField("_input");
+        input.setAccessible(true);
+        input.set(reader, new LongUTFDataInputStream(new ByteArrayInputStream(bos.toByteArray())));
+
+        byte[] result = reader.readByteArray();
+
+        assertEquals(len, result.length);
+        assertArrayEquals(payload, result);
+    }
+}


### PR DESCRIPTION
NegativeArraySizeException while reloading a compiled schema (.xsb):

    java.lang.NegativeArraySizeException: -25536
        at ...XsbReader.readByteArray(XsbReader.java:1759)

Found this diffing the read against the write path. writeByteArray stores the length with writeShort, which takes any unsigned short (0..65535), and every other length in XsbReader is read back through the unsigned readShort() helper. readByteArray is the only spot that reads the length with the raw signed _input.readShort(), so anything above 32767 comes back negative. 40000 wraps to -25536 and new byte[len] throws.

Reachable on reload of a BigInteger value (a particle minOccurs/maxOccurs, a default/fixed, a hexBinary/base64 value) whose two-complement byte form lands in 32768..65534, or a crafted .xsb with the high bit set on that length. It is also a plain round-trip bug: such an array can be written but not read back.

Reading it as an unsigned short lines up with the writer and the rest of the class.