### PR TITLE
guard out-of-range string code in StringPool.stringForCode

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
+++ b/src/main/java/org/apache/xmlbeans/impl/schema/SchemaTypeSystemImpl.java
@@ -692,6 +692,9 @@ public class SchemaTypeSystemImpl extends SchemaTypeLoaderBase implements Schema
         }
 
         String stringForCode(int code) {
+            if (code < 0 || code >= intsToStrings.size()) {
+                throw new SchemaTypeLoaderException("String code " + code + " out of range", _name, _handle, SchemaTypeLoaderException.UNRECOGNIZED_INDEX_ENTRY);
+            }
             return code == 0 ? null : intsToStrings.get(code);
         }
 

--- a/src/test/java/org/apache/xmlbeans/impl/schema/StringPoolCodeTest.java
+++ b/src/test/java/org/apache/xmlbeans/impl/schema/StringPoolCodeTest.java
@@ -1,0 +1,46 @@
+/*   Copyright 2026 The Apache Software Foundation
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.xmlbeans.impl.schema;
+
+import org.apache.xmlbeans.SchemaTypeLoaderException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class StringPoolCodeTest {
+
+    @Test
+    void stringForCodeRejectsOutOfRange() {
+        SchemaTypeSystemImpl.StringPool pool = new SchemaTypeSystemImpl.StringPool("handle", "name");
+        int code = pool.codeForString("abc");
+
+        assertNull(pool.stringForCode(0));
+        assertEquals("abc", pool.stringForCode(code));
+
+        // a code past the end of the pool, as read from a crafted .xsb, must
+        // surface as the documented loader exception, not IndexOutOfBoundsException
+        assertThrows(SchemaTypeLoaderException.class, () -> pool.stringForCode(code + 1));
+    }
+
+    @Test
+    void stringForCodeRejectsNegative() {
+        SchemaTypeSystemImpl.StringPool pool = new SchemaTypeSystemImpl.StringPool("handle", "name");
+        // readUnsignedShortOrInt() falls back to a signed readInt() for the 0xffff
+        // marker, so a negative code can reach stringForCode
+        assertThrows(SchemaTypeLoaderException.class, () -> pool.stringForCode(-1));
+    }
+}


### PR DESCRIPTION
Came across this while feeding a truncated .xsb at the schema loader and watching where it fell over.

    java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 1
        at java.base/java.util.ArrayList.get(ArrayList.java:427)
        at org.apache.xmlbeans.impl.schema.SchemaTypeSystemImpl$StringPool.stringForCode(SchemaTypeSystemImpl.java:695)
        at org.apache.xmlbeans.impl.schema.XsbReader.readString(XsbReader.java:298)

1. stringForCode takes a pool index straight off the .xsb stream and hands it to intsToStrings.get(code) with no range check.
2. readString reads that index through readUnsignedShortOrInt, which falls back to a signed readInt for the 0xffff marker, so a crafted file can make it negative or larger than the pool.
3. the loader only wraps IOException, so the get() escapes as IndexOutOfBoundsException rather than the SchemaTypeLoaderException callers are meant to see.

Guarded the index and threw SchemaTypeLoaderException the same way the rest of the pool reports trouble. Valid files read back unchanged.