### PR TITLE
escape ]]> in element content in OptimizedForSpeedSaver

### DIFF
--- a/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
+++ b/src/main/java/org/apache/xmlbeans/impl/store/Saver.java
@@ -2074,10 +2074,11 @@ abstract class Saver {
             int cch = c._cchSrc;
             int off = c._offSrc;
             int index = 0;
+            int trailingBrackets = 0;
             while (index < cch) {
                 int indexLimit = Math.min(index + 512, cch);
                 CharUtil.getChars(_buf, 0, src, off + index, indexLimit - index);
-                entitizeAndWriteText(indexLimit - index);
+                trailingBrackets = entitizeAndWriteText(indexLimit - index, trailingBrackets);
                 index = indexLimit;
             }
         }
@@ -2113,7 +2114,7 @@ abstract class Saver {
             }
         }
 
-        private void entitizeAndWriteText(int bufLimit) {
+        private int entitizeAndWriteText(int bufLimit, int trailingBrackets) {
             int index = 0;
             for (int i = 0; i < bufLimit; i++) {
                 char c = _buf[i];
@@ -2122,15 +2123,33 @@ abstract class Saver {
                         emit(_buf, index, i - index);
                         emit("&lt;");
                         index = i + 1;
+                        trailingBrackets = 0;
                         break;
                     case '&':
                         emit(_buf, index, i - index);
                         emit("&amp;");
                         index = i + 1;
+                        trailingBrackets = 0;
+                        break;
+                    case '>':
+                        // ']]>' is not allowed in content, so escape the '>' that closes it
+                        if (trailingBrackets >= 2) {
+                            emit(_buf, index, i - index);
+                            emit("&gt;");
+                            index = i + 1;
+                        }
+                        trailingBrackets = 0;
+                        break;
+                    case ']':
+                        trailingBrackets++;
+                        break;
+                    default:
+                        trailingBrackets = 0;
                         break;
                 }
             }
             emit(_buf, index, bufLimit - index);
+            return trailingBrackets;
         }
 
         private void entitizeAndWriteCommentText(int bufLimit) {

--- a/src/test/java/misc/checkin/SaveOptimizeForSpeedTest.java
+++ b/src/test/java/misc/checkin/SaveOptimizeForSpeedTest.java
@@ -67,6 +67,38 @@ public class SaveOptimizeForSpeedTest {
     }
 
     @Test
+    void testCDataEndInText() throws Exception {
+        XmlObject o = XmlObject.Factory.parse("<root/>");
+        try (XmlCursor cur = o.newCursor()) {
+            cur.toFirstChild();
+            cur.toFirstContentToken();
+            cur.insertChars("a]]>b");
+        }
+        String out = saveForSpeed(o);
+        // ']]>' is forbidden in element content and must be escaped to ']]&gt;'
+        assertFalse(out.contains("]]>"));
+        // before the fix the literal ']]>' makes this a fatal parse error
+        XmlObject.Factory.parse(out);
+    }
+
+    @Test
+    void testCDataEndAcrossChunkBoundary() throws Exception {
+        // a ']]>' that straddles the 512-char chunk boundary: ']]' end the first
+        // chunk, '>' is the first char of the second. The trailing-bracket state
+        // has to carry across chunks or the '>' is emitted unescaped.
+        String data = repeat('x', 510) + "]]>" + repeat('y', 600);
+        XmlObject o = XmlObject.Factory.parse("<root/>");
+        try (XmlCursor cur = o.newCursor()) {
+            cur.toFirstChild();
+            cur.toFirstContentToken();
+            cur.insertChars(data);
+        }
+        String out = saveForSpeed(o);
+        assertFalse(out.contains("]]>"));
+        XmlObject.Factory.parse(out);
+    }
+
+    @Test
     void testProcInstTerminatorAcrossChunkBoundary() throws Exception {
         // a '?>' that straddles the 512-char chunk boundary: '?' is the last char
         // of the first chunk, '>' the first char of the second. The per-chunk


### PR DESCRIPTION
Found while round-tripping content through the speed saver. Set an element's text to `a]]>b`, save with `setSaveOptimizeForSpeed(true)`, parse the result back:

    org.apache.xmlbeans.XmlException: error: The character sequence "]]>" must not appear in content unless used to mark the end of a CDATA section.

`OptimizedForSpeedSaver.entitizeAndWriteText` escapes only `<` and `&`. The default `TextSaver.entitizeContent` also rewrites the `>` that closes a `]]>` to `&gt;`, since `]]>` is not allowed in character data. Same input, two outputs:

    speed   : <root>a]]>b</root>
    default : <root>a]]&gt;b</root>

Only the speed one is malformed. The attribute and pi paths had drifted from the default saver in the same way before.

`entitizeAndWriteText` now escapes the closing `>` of a `]]>`, and `emitText` threads the trailing-`]` count through the 512-char chunk loop so a `]]>` that straddles a boundary is caught too.
